### PR TITLE
Swapped out completeSuffix() with suffix()

### DIFF
--- a/src/uconfig_gui/importer/filepage.cpp
+++ b/src/uconfig_gui/importer/filepage.cpp
@@ -112,7 +112,7 @@ void FilePage::checkEntry(const QString &text)
 {
     QFileInfo info(text);
     QPalette palette = _fileEdit->palette();
-    if (!_suffixes.contains(info.completeSuffix(), Qt::CaseInsensitive) || !info.exists())
+    if (!_suffixes.contains(info.suffix(), Qt::CaseInsensitive) || !info.exists())
     {
         _complete = false;
         emit completeChanged();


### PR DESCRIPTION
Hey there! Using `completeSuffix()` breaks handling PDF documents where there's a dot anywhere in the name, like `DS-000189-ICM-20948-v1.3.pdf` So would it make sense to use `suffix()` instead? Great project btw!