### PR TITLE
Explicit `<QtCore/qglobal.h>` includes

### DIFF
--- a/src/kicad/itemmodel/componentlibitemmodel.h
+++ b/src/kicad/itemmodel/componentlibitemmodel.h
@@ -19,6 +19,7 @@
 #ifndef COMPONENTLIBITEMMODEL_H
 #define COMPONENTLIBITEMMODEL_H
 
+#include <QtCore/qglobal.h>
 #include <QAbstractItemModel>
 
 #include "model/lib.h"

--- a/src/kicad/itemmodel/componentlibtreeview.h
+++ b/src/kicad/itemmodel/componentlibtreeview.h
@@ -19,8 +19,8 @@
 #ifndef COMPONENTLIBTREEVIEW_H
 #define COMPONENTLIBTREEVIEW_H
 
+#include <QtCore/qglobal.h>
 #include <QTreeView>
-
 #include <QAction>
 
 #include "componentlibitemmodel.h"

--- a/src/kicad/itemmodel/componentpindelegate.h
+++ b/src/kicad/itemmodel/componentpindelegate.h
@@ -19,6 +19,7 @@
 #ifndef COMPONENTPINDELEGATE_H
 #define COMPONENTPINDELEGATE_H
 
+#include <QtCore/qglobal.h>
 #include <QItemDelegate>
 #include <QRegularExpression>
 

--- a/src/kicad/itemmodel/pinlisteditor.h
+++ b/src/kicad/itemmodel/pinlisteditor.h
@@ -19,11 +19,11 @@
 #ifndef PINLISTEDITOR_H
 #define PINLISTEDITOR_H
 
-#include "componentpinstableview.h"
-
+#include <QtCore/qglobal.h>
 #include <QWidget>
-
 #include <QLineEdit>
+
+#include "componentpinstableview.h"
 
 class KICAD_EXPORT PinListEditor : public QWidget
 {

--- a/src/kicad/model/draw.h
+++ b/src/kicad/model/draw.h
@@ -19,6 +19,7 @@
 #ifndef DRAW_H
 #define DRAW_H
 
+#include <QtCore/qglobal.h>
 #include <QPoint>
 
 class Component;

--- a/src/kicad/model/drawarc.h
+++ b/src/kicad/model/drawarc.h
@@ -19,6 +19,8 @@
 #ifndef DRAWARC_H
 #define DRAWARC_H
 
+#include <QtCore/qglobal.h>
+
 #include "draw.h"
 
 class KICAD_EXPORT DrawArc : public Draw

--- a/src/kicad/model/drawcircle.h
+++ b/src/kicad/model/drawcircle.h
@@ -19,6 +19,8 @@
 #ifndef DRAWCIRCLE_H
 #define DRAWCIRCLE_H
 
+#include <QtCore/qglobal.h>
+
 #include "draw.h"
 
 class KICAD_EXPORT DrawCircle : public Draw

--- a/src/kicad/model/drawpoly.h
+++ b/src/kicad/model/drawpoly.h
@@ -19,9 +19,11 @@
 #ifndef DRAWPOLY_H
 #define DRAWPOLY_H
 
+#include <QtCore/qglobal.h>
+#include <QList>
+
 #include "draw.h"
 
-#include <QList>
 
 class KICAD_EXPORT DrawPoly : public Draw
 {

--- a/src/kicad/model/drawrect.h
+++ b/src/kicad/model/drawrect.h
@@ -19,9 +19,10 @@
 #ifndef DRAWRECT_H
 #define DRAWRECT_H
 
-#include "draw.h"
-
+#include <QtCore/qglobal.h>
 #include <QRect>
+
+#include "draw.h"
 
 class KICAD_EXPORT DrawRect : public Draw
 {

--- a/src/kicad/model/drawtext.h
+++ b/src/kicad/model/drawtext.h
@@ -19,9 +19,11 @@
 #ifndef DRAWTEXT_H
 #define DRAWTEXT_H
 
+#include <QtCore/qglobal.h>
+#include <QString>
+
 #include "draw.h"
 
-#include <QString>
 
 class KICAD_EXPORT DrawText : public Draw
 {

--- a/src/kicad/model/lib.h
+++ b/src/kicad/model/lib.h
@@ -19,9 +19,11 @@
 #ifndef LIB_H
 #define LIB_H
 
-#include "component.h"
+#include <QtCore/qglobal.h>
 #include <QList>
 #include <QString>
+
+#include "component.h"
 
 class KICAD_EXPORT Lib
 {

--- a/src/kicad/model/pad.h
+++ b/src/kicad/model/pad.h
@@ -19,6 +19,7 @@
 #ifndef PAD_H
 #define PAD_H
 
+#include <QtCore/qglobal.h>
 #include <QPointF>
 #include <QSizeF>
 #include <QString>

--- a/src/kicad/model/pin.h
+++ b/src/kicad/model/pin.h
@@ -19,6 +19,7 @@
 #ifndef PIN_H
 #define PIN_H
 
+#include <QtCore/qglobal.h>
 #include <QPoint>
 #include <QString>
 #include <QTextStream>

--- a/src/kicad/parser/abstractlibparser.h
+++ b/src/kicad/parser/abstractlibparser.h
@@ -20,6 +20,7 @@
 #define ABSTRACTLIBPARSER_H
 
 #include <QtCore/qglobal.h>
+#include <QtCore/qglobal.h>
 
 #include "../model/lib.h"
 

--- a/src/kicad/parser/kicadlibparser.h
+++ b/src/kicad/parser/kicadlibparser.h
@@ -19,9 +19,10 @@
 #ifndef KICADLIBPARSER_H
 #define KICADLIBPARSER_H
 
-#include "abstractlibparser.h"
-
+#include <QtCore/qglobal.h>
 #include <QTextStream>
+
+#include "abstractlibparser.h"
 
 class KICAD_EXPORT KicadLibParser : public AbstractLibParser
 {

--- a/src/kicad/parser/libparser.h
+++ b/src/kicad/parser/libparser.h
@@ -19,6 +19,8 @@
 #ifndef LIBPARSER_H
 #define LIBPARSER_H
 
+#include <QtCore/qglobal.h>
+
 #include <model/lib.h>
 
 class KICAD_EXPORT LibParser

--- a/src/kicad/pinruler/classrule.h
+++ b/src/kicad/pinruler/classrule.h
@@ -19,6 +19,7 @@
 #ifndef CLASSRULE_H
 #define CLASSRULE_H
 
+#include <QtCore/qglobal.h>
 #include <QString>
 #include <QStringList>
 

--- a/src/kicad/pinruler/pinclass.h
+++ b/src/kicad/pinruler/pinclass.h
@@ -19,6 +19,7 @@
 #ifndef PINCLASS_H
 #define PINCLASS_H
 
+#include <QtCore/qglobal.h>
 #include <QList>
 #include <QRect>
 #include <QString>

--- a/src/kicad/pinruler/pinclassitem.h
+++ b/src/kicad/pinruler/pinclassitem.h
@@ -19,6 +19,8 @@
 #ifndef PINCLASSITEM_H
 #define PINCLASSITEM_H
 
+#include <QtCore/qglobal.h>
+
 #include "model/pin.h"
 
 class KICAD_EXPORT PinClassItem

--- a/src/kicad/pinruler/pinrule.h
+++ b/src/kicad/pinruler/pinrule.h
@@ -19,6 +19,7 @@
 #ifndef PINRULE_H
 #define PINRULE_H
 
+#include <QtCore/qglobal.h>
 #include <QString>
 #include <QStringList>
 

--- a/src/kicad/pinruler/pinruler.h
+++ b/src/kicad/pinruler/pinruler.h
@@ -19,6 +19,7 @@
 #ifndef PINRULER_H
 #define PINRULER_H
 
+#include <QtCore/qglobal.h>
 #include <QString>
 
 #include "model/component.h"

--- a/src/kicad/pinruler/rule.h
+++ b/src/kicad/pinruler/rule.h
@@ -19,6 +19,7 @@
 #ifndef RULE_H
 #define RULE_H
 
+#include <QtCore/qglobal.h>
 #include <QRegularExpression>
 #include <QString>
 

--- a/src/kicad/pinruler/rulesparser.h
+++ b/src/kicad/pinruler/rulesparser.h
@@ -19,6 +19,7 @@
 #ifndef RULESPARSER_H
 #define RULESPARSER_H
 
+#include <QtCore/qglobal.h>
 #include <QString>
 #include <QStringList>
 

--- a/src/kicad/pinruler/rulesset.h
+++ b/src/kicad/pinruler/rulesset.h
@@ -19,6 +19,7 @@
 #ifndef RULESSET_H
 #define RULESSET_H
 
+#include <QtCore/qglobal.h>
 #include <QList>
 #include <QString>
 

--- a/src/kicad/schematicsimport/textimporter.h
+++ b/src/kicad/schematicsimport/textimporter.h
@@ -19,6 +19,8 @@
 #ifndef TEXTIMPORTER_H
 #define TEXTIMPORTER_H
 
+#include <QtCore/qglobal.h>
+
 #include "schematicsimport/schematicsimporter.h"
 
 class KICAD_EXPORT TextImporter : public SchematicsImporter

--- a/src/kicad/viewer/componentitem.h
+++ b/src/kicad/viewer/componentitem.h
@@ -19,6 +19,7 @@
 #ifndef COMPONENTITEM_H
 #define COMPONENTITEM_H
 
+#include <QtCore/qglobal.h>
 #include <QGraphicsItem>
 #include <QMap>
 

--- a/src/kicad/viewer/componentscene.h
+++ b/src/kicad/viewer/componentscene.h
@@ -19,6 +19,7 @@
 #ifndef COMPONENTSCENE_H
 #define COMPONENTSCENE_H
 
+#include <QtCore/qglobal.h>
 #include <QGraphicsScene>
 
 #include "componentitem.h"

--- a/src/kicad/viewer/componentviewer.h
+++ b/src/kicad/viewer/componentviewer.h
@@ -19,6 +19,7 @@
 #ifndef MODULEVIEWER_H
 #define MODULEVIEWER_H
 
+#include <QtCore/qglobal.h>
 #include <QGraphicsView>
 #include <QList>
 

--- a/src/kicad/viewer/componentwidget.h
+++ b/src/kicad/viewer/componentwidget.h
@@ -19,6 +19,7 @@
 #ifndef COMPONENTWIDGET_H
 #define COMPONENTWIDGET_H
 
+#include <QtCore/qglobal.h>
 #include <QActionGroup>
 #include <QComboBox>
 #include <QToolButton>

--- a/src/kicad/viewer/drawcircleitem.h
+++ b/src/kicad/viewer/drawcircleitem.h
@@ -19,6 +19,8 @@
 #ifndef DRAWCIRCLEITEM_H
 #define DRAWCIRCLEITEM_H
 
+#include <QtCore/qglobal.h>
+
 #include "drawitem.h"
 
 #include "model/drawcircle.h"

--- a/src/kicad/viewer/drawitem.h
+++ b/src/kicad/viewer/drawitem.h
@@ -19,8 +19,10 @@
 #ifndef DRAWITEM_H
 #define DRAWITEM_H
 
-#include "model/draw.h"
+#include <QtCore/qglobal.h>
 #include <QGraphicsItem>
+
+#include "model/draw.h"
 
 class KICAD_EXPORT DrawItem : public QGraphicsItem
 {

--- a/src/kicad/viewer/drawpolyitem.h
+++ b/src/kicad/viewer/drawpolyitem.h
@@ -19,6 +19,8 @@
 #ifndef DRAWPOLYITEM_H
 #define DRAWPOLYITEM_H
 
+#include <QtCore/qglobal.h>
+
 #include "drawitem.h"
 
 #include "model/drawpoly.h"

--- a/src/kicad/viewer/drawrectitem.h
+++ b/src/kicad/viewer/drawrectitem.h
@@ -19,6 +19,8 @@
 #ifndef DRAWRECTITEM_H
 #define DRAWRECTITEM_H
 
+#include <QtCore/qglobal.h>
+
 #include "drawitem.h"
 
 #include "model/drawrect.h"

--- a/src/kicad/viewer/drawtextitem.h
+++ b/src/kicad/viewer/drawtextitem.h
@@ -19,6 +19,8 @@
 #ifndef DRAWTEXTITEM_H
 #define DRAWTEXTITEM_H
 
+#include <QtCore/qglobal.h>
+
 #include "drawitem.h"
 #include "kicadfont.h"
 

--- a/src/kicad/viewer/kicadfont.h
+++ b/src/kicad/viewer/kicadfont.h
@@ -19,6 +19,7 @@
 #ifndef KICADFONT_H
 #define KICADFONT_H
 
+#include <QtCore/qglobal.h>
 #include <QFont>
 #include <QPainter>
 #include <QString>

--- a/src/kicad/viewer/pinitem.h
+++ b/src/kicad/viewer/pinitem.h
@@ -19,6 +19,7 @@
 #ifndef PINITEM_H
 #define PINITEM_H
 
+#include <QtCore/qglobal.h>
 #include <QGraphicsItem>
 
 #include "model/pin.h"


### PR DESCRIPTION
Explicitly include `<QtCore/qglobal.h>` in every header that uses `KICAD_EXPORT`