### PR TITLE
Fixes for Qt code

### DIFF
--- a/src/kicad/itemmodel/componentlibtreeview.cpp
+++ b/src/kicad/itemmodel/componentlibtreeview.cpp
@@ -129,7 +129,7 @@ void ComponentLibTreeView::remove()
             return;
         }
         QList<QPersistentModelIndex> pindex;
-        for (QModelIndex selected : selection)
+        for (QModelIndex selected : qAsConst(selection))
         {
             const QModelIndex &indexComponent = _sortProxy->mapToSource(selected);
             if (!indexComponent.isValid() || indexComponent.column() != 0)

--- a/src/kicad/itemmodel/componentpinsitemmodel.cpp
+++ b/src/kicad/itemmodel/componentpinsitemmodel.cpp
@@ -299,7 +299,7 @@ QString ComponentPinsItemModel::toNumeric(const QString &str)
 {
     QString sortPatern = str;
 
-    QRegularExpression numPattern("([^0-9]*)([0-9]+)([^0-9]*)", QRegularExpression::CaseInsensitiveOption);
+    static QRegularExpression numPattern("([^0-9]*)([0-9]+)([^0-9]*)", QRegularExpression::CaseInsensitiveOption);
 
     QRegularExpressionMatchIterator numMatchIt = numPattern.globalMatch(str);
     if (numMatchIt.hasNext())
@@ -321,7 +321,7 @@ void ComponentPinsItemModel::updateHigherPin()
     QString higherNumPin = QString();
     if (_component != nullptr)
     {
-        for (Pin *pin : _component->pins())
+        for (Pin *pin : qAsConst(_component->pins()))
         {
             QString numPin = toNumeric(pin->padName());
             if (numPin > higherNumPin)
@@ -330,7 +330,7 @@ void ComponentPinsItemModel::updateHigherPin()
                 higherNumPin = numPin;
             }
         }
-        QRegularExpression higherNumPinPattern("([A-Z]*0*)([1-9][0-9]*)", QRegularExpression::CaseInsensitiveOption);
+        static QRegularExpression higherNumPinPattern("([A-Z]*0*)([1-9][0-9]*)", QRegularExpression::CaseInsensitiveOption);
         QRegularExpressionMatchIterator higherNumPinMatchIt = higherNumPinPattern.globalMatch(_higherPin);
         if (higherNumPinMatchIt.hasNext())
         {

--- a/src/kicad/itemmodel/componentpinstableview.cpp
+++ b/src/kicad/itemmodel/componentpinstableview.cpp
@@ -126,7 +126,7 @@ void ComponentPinsTableView::remove()
     if (!selection.empty())
     {
         QList<QPersistentModelIndex> pindex;
-        for (QModelIndex selected : selection)
+        for (QModelIndex selected : qAsConst(selection))
         {
             const QModelIndex &indexComponent = _sortProxy->mapToSource(selected);
             if (!indexComponent.isValid())
@@ -174,7 +174,8 @@ void ComponentPinsTableView::updateSelect(const QItemSelection &selected, const 
     Q_UNUSED(deselected)
 
     QSet<Pin *> selectedPins;
-    for (const QModelIndex &index : selectionModel()->selectedIndexes())
+    const auto& selected_idx = selectionModel()->selectedIndexes();
+    for (const QModelIndex &index : selected_idx)
     {
         if (!index.isValid())
         {

--- a/src/kicad/ksseditor/ksssyntax.cpp
+++ b/src/kicad/ksseditor/ksssyntax.cpp
@@ -46,7 +46,7 @@ KSSSyntax::KSSSyntax(QTextDocument *parent)
                     << "label"
                     << "rect"
                     << "priority";
-    for (const QString &pattern : keywordPatterns)
+    for (const QString &pattern : qAsConst(keywordPatterns))
     {
         rule.pattern.setPattern("\\b(" + pattern + ")\\b");
         rule.format = keywordFormat;
@@ -89,7 +89,7 @@ KSSSyntax::KSSSyntax(QTextDocument *parent)
                        << "faledge"
                        << "nologic";
 
-    for (const QString &pattern : enumvaluesPatterns)
+    for (const QString &pattern : qAsConst(enumvaluesPatterns))
     {
         rule.pattern.setPattern("\\b(" + pattern + ")\\b");
         rule.format = enumvaluesFormat;
@@ -117,7 +117,7 @@ void KSSSyntax::highlightBlock(const QString &text)
     PartToHighlight highlight;
 
     partsToHighlight.clear();
-    for (const HighlightingRule &rule : highlightingRules)
+    for (const HighlightingRule &rule : qAsConst(highlightingRules))
     {
         QRegularExpressionMatch match = rule.pattern.match(text);
         if (match.hasMatch())

--- a/src/kicad/pinruler/pinclass.cpp
+++ b/src/kicad/pinruler/pinclass.cpp
@@ -122,10 +122,10 @@ void PinClass::sortPins()
         return;
     }
 
-    QRegularExpression pattern(_sortPattern, QRegularExpression::CaseInsensitiveOption);
-    QRegularExpression numPattern("([^0-9]*)([0-9]+)([^0-9]*)", QRegularExpression::CaseInsensitiveOption);
+    static QRegularExpression pattern(_sortPattern, QRegularExpression::CaseInsensitiveOption);
+    static QRegularExpression numPattern("([^0-9]*)([0-9]+)([^0-9]*)", QRegularExpression::CaseInsensitiveOption);
 
-    for (PinClassItem *pinItem : _pins)
+    for (PinClassItem *pinItem : qAsConst(_pins))
     {
         QString sortPatern;
         QString pinName = pinItem->pin()->name();
@@ -220,7 +220,7 @@ void PinClass::setPos(const QPoint &basePos)
             break;
     }
     sortPins();
-    for (PinClassItem *pinItem : _pins)
+    for (PinClassItem *pinItem : qAsConst(_pins))
     {
         pinItem->pin()->setAngle(angle);
         pinItem->pin()->setPos(pinPos + translate);

--- a/src/kicad/pinruler/pinruler.cpp
+++ b/src/kicad/pinruler/pinruler.cpp
@@ -59,7 +59,7 @@ void PinRuler::organize(Component *component)
     component->clearDraws();
 
     PinClass *defaultClass = pinClass("default");
-    for (Pin *pin : component->pins())
+    for (Pin *pin : qAsConst(component->pins()))
     {
         PinClassItem *pinClassItem = new PinClassItem(pin);
         const QList<PinRule *> &rules = _ruleSet->rulesForPin(pin->name());
@@ -131,7 +131,7 @@ void PinRuler::organize(Component *component)
     QSize leftSize = QSize(0, 0);
     QSize rightSize = QSize(0, 0);
     QSize removedSize = QSize(0, 0);
-    for (PinClass *mpinClass : _pinClasses)
+    for (PinClass *mpinClass : qAsConst(_pinClasses))
     {
         if (mpinClass->pins().count() == 0)
         {
@@ -337,7 +337,7 @@ void PinRuler::organize(Component *component)
     component->refText()->setTextHJustify(DrawText::TextHLeft);
     component->refText()->setDirection(DrawText::DirectionHorizontal);
 
-    for (PinClass *mpinClass : _pinClasses)
+    for (PinClass *mpinClass : qAsConst(_pinClasses))
     {
         delete mpinClass;
     }

--- a/src/kicad/pinruler/rulesparser.cpp
+++ b/src/kicad/pinruler/rulesparser.cpp
@@ -172,8 +172,8 @@ void RulesParser::skipSpaceAndComments()
 
 QString RulesParser::getSelector()
 {
-    QRegularExpression rule(R"((\.?[a-zA-Z\(\[\.][/a-zA-Z0-9\+\-\[\]\(\)\_\|\\\*\.\^$\?:]*))");
-    QRegularExpressionMatch ruleMath = rule.match(_data.mid(_id));
+    static QRegularExpression rule(R"((\.?[a-zA-Z\(\[\.][/a-zA-Z0-9\+\-\[\]\(\)\_\|\\\*\.\^$\?:]*))");
+    static QRegularExpressionMatch ruleMath = rule.match(_data.mid(_id));
     if (ruleMath.hasMatch() && ruleMath.capturedStart() != 0)
     {
         return QString();
@@ -205,7 +205,7 @@ QString RulesParser::getSelector()
 
 QString RulesParser::getPropertyName()
 {
-    QRegularExpression rule("([a-zA-Z][a-zA-Z0-9\\_\\-]*)[\t ]*:[\t ]*", QRegularExpression::MultilineOption | QRegularExpression::DotMatchesEverythingOption);
+    static QRegularExpression rule("([a-zA-Z][a-zA-Z0-9\\_\\-]*)[\t ]*:[\t ]*", QRegularExpression::MultilineOption | QRegularExpression::DotMatchesEverythingOption);
     QRegularExpressionMatch ruleMath = rule.match(_data.mid(_id));
     if (ruleMath.hasMatch() && ruleMath.capturedStart() != 0)
     {
@@ -217,7 +217,7 @@ QString RulesParser::getPropertyName()
 
 QString RulesParser::getPropertyValue()
 {
-    QRegularExpression rule(R"lit("?([a-zA-Z0-9/^\?\$\|:\_\-\+\\\[\]\(\)\.\* ]*)"?;?)lit",
+    static QRegularExpression rule(R"lit("?([a-zA-Z0-9/^\?\$\|:\_\-\+\\\[\]\(\)\.\* ]*)"?;?)lit",
                             QRegularExpression::MultilineOption | QRegularExpression::DotMatchesEverythingOption);
     QRegularExpressionMatch ruleMath = rule.match(_data.mid(_id));
     if (ruleMath.hasMatch() && ruleMath.capturedStart() != 0)

--- a/src/kicad/viewer/componentitem.cpp
+++ b/src/kicad/viewer/componentitem.cpp
@@ -57,7 +57,7 @@ void ComponentItem::setComponent(Component *component, int unit)
     _pinItemMap.clear();
     _unit = unit;
 
-    for (Pin *pin : component->pins())
+    for (Pin *pin : qAsConst(component->pins()))
     {
         if (pin->unit() == _unit || pin->unit() == 0)
         {
@@ -66,7 +66,7 @@ void ComponentItem::setComponent(Component *component, int unit)
             _pinItemMap.insert(pin, pinItem);
         }
     }
-    for (Draw *draw : component->draws())
+    for (Draw *draw : qAsConst(component->draws()))
     {
         if (draw->unit() == _unit || draw->unit() == 0)
         {
@@ -115,7 +115,7 @@ void ComponentItem::setShowElectricalType(bool showElectricalType)
 {
     if (showElectricalType != _showElectricalType)
     {
-        for (PinItem *pinItem : _pinItemMap)
+        for (PinItem *pinItem : qAsConst(_pinItemMap))
         {
             pinItem->setShowElectricalType(showElectricalType);
         }

--- a/src/kicad/viewer/componentviewer.cpp
+++ b/src/kicad/viewer/componentviewer.cpp
@@ -164,7 +164,8 @@ void ComponentViewer::selectedItem()
 {
     QList<Pin *> selectedPins;
 
-    for (QGraphicsItem *item : scene()->selectedItems())
+    const auto& selected = scene()->selectedItems();
+    for (QGraphicsItem *item : selected)
     {
         PinItem *pinItem = qgraphicsitem_cast<PinItem *>(item);
         selectedPins.append(pinItem->pin());

--- a/src/kicad/viewer/drawpolyitem.cpp
+++ b/src/kicad/viewer/drawpolyitem.cpp
@@ -48,7 +48,7 @@ void DrawPolyItem::paint(QPainter *painter, const QStyleOptionGraphicsItem *opti
     }
 
     QPolygon poly;
-    for (QPoint pt : _drawPoly->points())
+    for (QPoint pt : qAsConst(_drawPoly->points()))
     {
         poly.append(pt / ComponentItem::ratio);
     }
@@ -66,7 +66,7 @@ void DrawPolyItem::setDraw(DrawPoly *draw)
     _drawPoly = draw;
     QRect mrect(0, 0, 1, 1);
 
-    for (QPoint pt : _drawPoly->points())
+    for (QPoint pt : qAsConst(_drawPoly->points()))
     {
         mrect = mrect.united(QRect(pt / ComponentItem::ratio, QSize(1, 1)));
     }

--- a/src/pdf_extract/model/pdfpage.cpp
+++ b/src/pdf_extract/model/pdfpage.cpp
@@ -32,7 +32,7 @@ PDFPage::PDFPage(PDFDatasheet *datasheet, int numPage)
 
 PDFPage::~PDFPage()
 {
-    for (PDFTextBox *textBox : _textBoxes)
+    for (PDFTextBox *textBox : qAsConst(_textBoxes))
     {
         delete textBox;
     }

--- a/src/pdf_extract/model/pdftextbox.cpp
+++ b/src/pdf_extract/model/pdftextbox.cpp
@@ -31,7 +31,7 @@ PDFTextBox::PDFTextBox(QString text, const QRectF &boundingRect)
 
 PDFTextBox::~PDFTextBox()
 {
-    for (PDFTextBox *textBox : _subBoxes)
+    for (PDFTextBox *textBox : qAsConst(_subBoxes))
     {
         delete textBox;
     }

--- a/src/test/test_libkicad.cpp
+++ b/src/test/test_libkicad.cpp
@@ -39,7 +39,7 @@ void test_libkicad()
         QStringList items = line.split(";");
 
         int i = 0;
-        for (const QString &item : items)
+        for (const QString &item : qAsConst(items))
         {
             if (i > 0 && !item.isEmpty())
             {
@@ -68,7 +68,7 @@ void test_libkicad()
         points.append(QPoint(1000 + 300 * i, 0));
     }
 
-    for (auto pin : component->pins())
+    for (auto pin : qAsConst(component->pins()))
     {
         if (pin->name() == "GND")
         {

--- a/src/uconfig_gui/importer/datasheetprocesspage.cpp
+++ b/src/uconfig_gui/importer/datasheetprocesspage.cpp
@@ -109,7 +109,8 @@ void DatasheetProcessPage::finish()
 
     qDeleteAll(components);
     components.clear();
-    for (Component *component : _thread->datasheet()->components())
+    const auto& component_list = _thread->datasheet()->components();
+    for (Component *component : component_list)
     {
         components.append(component);
     }

--- a/src/uconfig_gui/importer/filepage.cpp
+++ b/src/uconfig_gui/importer/filepage.cpp
@@ -147,7 +147,7 @@ void FilePage::fileExplore()
     }
 
     QString fileName = QFileDialog::getOpenFileName(
-        this, QString("Choose a %1 file").arg(_fileTitle), lastPath, QString("%1 (%2)").arg(_fileTitle).arg("*." + _suffixes.join(" *.")));
+        this, QString("Choose a %1 file").arg(_fileTitle), lastPath, QString("%1 (%2)").arg(_fileTitle, "*." + _suffixes.join(" *.")));
     if (!fileName.isEmpty())
     {
         setFile(fileName);

--- a/src/uconfig_gui/importer/filepage.h
+++ b/src/uconfig_gui/importer/filepage.h
@@ -37,7 +37,7 @@ public:
     int nextId() const override;
     void initializePage() override;
 
-    Q_PROPERTY(QString file READ file)
+    Q_PROPERTY(QString file CONSTANT READ file)
     QString file() const;
 
 protected:

--- a/src/uconfig_gui/importer/pdffilepage.cpp
+++ b/src/uconfig_gui/importer/pdffilepage.cpp
@@ -112,7 +112,7 @@ void PDFFilePage::check()
         {
             int start = -1;
             int stop = -1;
-            QRegularExpression reg("^([0-9]+)(\\-[0-9]+)?$");
+            static QRegularExpression reg("^([0-9]+)(\\-[0-9]+)?$");
             QRegularExpressionMatch match = reg.match(_rangeEdit->text());
             start = match.captured(1).toInt() - 1;
             if (start >= _datasheetThread->datasheet()->pageCount() || start < 0)

--- a/src/uconfig_gui/project/uconfigproject.cpp
+++ b/src/uconfig_gui/project/uconfigproject.cpp
@@ -86,7 +86,7 @@ void UConfigProject::openLib(const QString &libFileName)
         }
         if (fileDialog.exec() != 0)
         {
-            mlibFileName = fileDialog.selectedFiles().first();
+            mlibFileName = fileDialog.selectedFiles().constFirst();
         }
         if (mlibFileName.isEmpty())
         {
@@ -125,6 +125,7 @@ void UConfigProject::saveLib()
 
 void UConfigProject::saveLibAs(const QString &fileName)
 {
+    static QRegularExpression pdf_or_cvs("(.*)\\.(pdf|csv)");
     QString libFileName;
 
     if (fileName.isEmpty())
@@ -137,12 +138,12 @@ void UConfigProject::saveLibAs(const QString &fileName)
         if (!_importedPathLib.isEmpty())
         {
             libFileName = _importedPathLib;
-            libFileName.replace(QRegularExpression("(.*)\\.(pdf|csv)"), "\\1.lib");
+            libFileName.replace(pdf_or_cvs, "\\1.lib");
             fileDialog.selectFile(libFileName);
         }
         if (fileDialog.exec() != 0)
         {
-            libFileName = fileDialog.selectedFiles().first();
+            libFileName = fileDialog.selectedFiles().constFirst();
         }
         if (libFileName.isEmpty())
         {
@@ -186,7 +187,8 @@ void UConfigProject::importComponents(const QString &fileName)
         return;
     }
 
-    for (Component *component : importer.components())
+    const auto& component_list = importer.components();
+    for (Component *component : component_list)
     {
         _lib->addComponent(component);
     }

--- a/src/uconfig_gui/project/uconfigproject.h
+++ b/src/uconfig_gui/project/uconfigproject.h
@@ -60,7 +60,7 @@ public slots:
 
     void selectComponent(Component *component);
 
-    void setComponentInfo(ComponentInfoType infoType, const QVariant &value);
+    void setComponentInfo(UConfigProject::ComponentInfoType infoType, const QVariant &value);
 
 signals:
     void libChanged(Lib *lib);

--- a/src/uconfig_gui/uconfig_gui.cpp
+++ b/src/uconfig_gui/uconfig_gui.cpp
@@ -35,7 +35,7 @@ int main(int argc, char *argv[])
     mainWindow.show();
     if (QApplication::arguments().size() > 1)
     {
-        QString fileArg = QApplication::arguments()[1];
+        QString fileArg = QApplication::arguments().at(1);
         if (fileArg.endsWith(".lib", Qt::CaseInsensitive))
         {
             project.openLib(fileArg);

--- a/src/uconfig_gui/uconfigmainwindow.cpp
+++ b/src/uconfig_gui/uconfigmainwindow.cpp
@@ -98,7 +98,8 @@ void UConfigMainWindow::dropEvent(QDropEvent *event)
 {
     event->accept();
 
-    for (const QUrl &url : event->mimeData()->urls())
+    const auto& urls = event->mimeData()->urls();
+    for (const QUrl &url : urls)
     {
         QString fileName = url.toLocalFile();
         _project->importComponents(fileName);
@@ -182,7 +183,8 @@ void UConfigMainWindow::reloadRuleSetList()
     _ruleComboBox->clear();
     _ruleComboBox->addItem(tr("package"));
     QDir dir(qApp->applicationDirPath() + "/../rules/");
-    for (const QFileInfo &ruleInfo : dir.entryInfoList(QStringList() << "*.kss", QDir::NoDotAndDotDot | QDir::Files))
+    const auto& entry_list = dir.entryInfoList(QStringList() << "*.kss", QDir::NoDotAndDotDot | QDir::Files);
+    for (const QFileInfo &ruleInfo : entry_list)
     {
         _ruleComboBox->addItem(ruleInfo.baseName());
     }
@@ -292,7 +294,7 @@ void UConfigMainWindow::updateOldProjects()
 {
     for (int i = 0; i < _project->oldProjects().size(); i++)
     {
-        QString path = _project->oldProjects()[i];
+        QString path = _project->oldProjects().at(i);
         _oldProjectsActions[i]->setVisible(true);
         _oldProjectsActions[i]->setData(path);
         _oldProjectsActions[i]->setText(QString("&%1. %2").arg(i + 1).arg(path));


### PR DESCRIPTION
Since Qt objects are based on reference counting/garbage collection, they can have some unexpected behaviors, specifically when dealing with lists. I have fixed many instance of different Qt related issues after being identified using Clazy.

https://github.com/KDE/clazy/blob/1.11/docs/checks/README-range-loop-detach.md
https://github.com/KDE/clazy/blob/1.11/docs/checks/README-detaching-temporary.md
https://github.com/KDE/clazy/blob/1.11/docs/checks/README-use-static-qregularexpression.md
https://github.com/KDE/clazy/blob/1.11/docs/checks/README-qproperty-without-notify.md