### PR TITLE
Use "angle" instead of "direction" for text

### DIFF
--- a/src/kicad/model/component.cpp
+++ b/src/kicad/model/component.cpp
@@ -585,8 +585,9 @@ void Component::reorganizeToPackageStyle()
     // set position of ref and name text
     _nameText->setPos(QPoint(rect.right(), rect.top() - 50));
     _nameText->setTextHJustify(DrawText::TextHRight);
-    _nameText->setDirection(DrawText::DirectionHorizontal);
+    _nameText->setAngle(0.0);
     _refText->setPos(QPoint(rect.left(), rect.bottom() + 50));
     _refText->setTextHJustify(DrawText::TextHLeft);
-    _refText->setDirection(DrawText::DirectionHorizontal);
+    _refText->setAngle(0.0);
+    ;
 }

--- a/src/kicad/model/drawtext.cpp
+++ b/src/kicad/model/drawtext.cpp
@@ -20,7 +20,7 @@
 
 DrawText::DrawText(const QString &text, const QPoint &pos)
 {
-    _direction = DirectionHorizontal;
+    _angle = 0.0;
     _textSize = 50;
     _textStyle = TextNormal;
     _visible = true;
@@ -50,14 +50,14 @@ void DrawText::setText(const QString &text)
     _text = text;
 }
 
-DrawText::Direction DrawText::direction() const
+qreal DrawText::angle(void) const
 {
-    return _direction;
+    return _angle;
 }
 
-void DrawText::setDirection(Direction direction)
+void DrawText::setAngle(qreal angle)
 {
-    _direction = direction;
+    _angle = angle;
 }
 
 uint DrawText::textSize() const

--- a/src/kicad/model/drawtext.h
+++ b/src/kicad/model/drawtext.h
@@ -20,6 +20,7 @@
 #define DRAWTEXT_H
 
 #include <QString>
+#include <QTransform>
 #include <QtCore/qglobal.h>
 
 #include "draw.h"
@@ -35,13 +36,8 @@ public:
     const QString &text() const;
     void setText(const QString &text);
 
-    enum Direction
-    {
-        DirectionHorizontal,
-        DirectionVertital
-    };
-    Direction direction() const;
-    void setDirection(Direction direction);
+    qreal angle(void) const;
+    void setAngle(qreal angle);
 
     uint textSize() const;
     void setTextSize(uint textSize);
@@ -79,7 +75,7 @@ public:
 
 protected:
     QString _text;
-    Direction _direction;
+    qreal _angle;
     uint _textSize;
     TextStyles _textStyle;
     bool _visible;

--- a/src/kicad/pinruler/pinclass.cpp
+++ b/src/kicad/pinruler/pinclass.cpp
@@ -313,22 +313,22 @@ DrawText *PinClass::getDrawText() const
         case ClassRule::PositionTop:
             height = qCeil(boundingRect().height() / 100.0) * 100 - 100;
             drawClassLabel->setPos(QPoint(_pos.x() + boundingRect().width() / 2 - 50, _pos.y() + 50 + height));
-            drawClassLabel->setDirection(DrawText::DirectionHorizontal);
+            drawClassLabel->setAngle(0.0);
             break;
         case ClassRule::PositionBottom:
             height = qCeil(boundingRect().height() / 100.0) * 100 - 100;
             drawClassLabel->setPos(QPoint(_pos.x() + boundingRect().width() / 2 - 50, _pos.y() - 50 - height));
-            drawClassLabel->setDirection(DrawText::DirectionHorizontal);
+            drawClassLabel->setAngle(0.0);
             break;
         case ClassRule::PositionLeft:
             width = qCeil(boundingRect().width() / 100.0) * 100 - 100;
             drawClassLabel->setPos(QPoint(_pos.x() + width + 50, _pos.y() - 50 + boundingRect().height() / 2));
-            drawClassLabel->setDirection(DrawText::DirectionVertital);
+            drawClassLabel->setAngle(90.0);
             break;
         case ClassRule::PositionRight:
             width = qCeil(boundingRect().width() / 100.0) * 100 - 100;
             drawClassLabel->setPos(QPoint(_pos.x() - width - 50, _pos.y() - 50 + boundingRect().height() / 2));
-            drawClassLabel->setDirection(DrawText::DirectionVertital);
+            drawClassLabel->setAngle(90.0);
             break;
         case ClassRule::PositionASide:
             break;

--- a/src/kicad/pinruler/pinruler.cpp
+++ b/src/kicad/pinruler/pinruler.cpp
@@ -332,10 +332,10 @@ void PinRuler::organize(Component *component)
     component->prependDraw(rectDraw);
     component->nameText()->setPos(QPoint(rect.right(), rect.bottom() + 50));
     component->nameText()->setTextHJustify(DrawText::TextHRight);
-    component->nameText()->setDirection(DrawText::DirectionHorizontal);
+    component->nameText()->setAngle(0.0);
     component->refText()->setPos(QPoint(rect.left(), rect.bottom() + 50));
     component->refText()->setTextHJustify(DrawText::TextHLeft);
-    component->refText()->setDirection(DrawText::DirectionHorizontal);
+    component->refText()->setAngle(0.0);
 
     for (PinClass *mpinClass : _pinClasses)
     {

--- a/src/kicad/viewer/drawtextitem.cpp
+++ b/src/kicad/viewer/drawtextitem.cpp
@@ -41,6 +41,7 @@ void DrawTextItem::paint(QPainter *painter, const QStyleOptionGraphicsItem *opti
 {
     Q_UNUSED(option)
     Q_UNUSED(widget)
+    Q_ASSERT(_fontText != nullptr);
 
     painter->setRenderHint(QPainter::Antialiasing);
     painter->setRenderHint(QPainter::TextAntialiasing);
@@ -64,17 +65,14 @@ void DrawTextItem::paint(QPainter *painter, const QStyleOptionGraphicsItem *opti
     }
     painter->setFont(font);
 
-    if (_drawText->direction() == DrawText::DirectionVertital)
-    {
-        painter->rotate(-90);
-    }
+    painter->rotate(_drawText->angle());
 
     _fontText->drawText(painter, _textRect, Qt::AlignLeft, _drawText->text());
 }
 
 QRectF DrawTextItem::boundingRect() const
 {
-    return _rect.adjusted(-20, -20, 20, 20);
+    return QTransform().rotate(_drawText->angle()).mapRect(_rect).adjusted(-20, -20, 20, 20);
 }
 
 void DrawTextItem::setDraw(DrawText *draw)
@@ -126,12 +124,6 @@ void DrawTextItem::setDraw(DrawText *draw)
     }
 
     _textRect = _rect;
-    if (_drawText->direction() == DrawText::DirectionVertital)
-    {
-        int swap = _rect.size().width();
-        _rect.setWidth(_rect.height());
-        _rect.setHeight(swap);
-    }
 
     setPos(draw->pos() / ComponentItem::ratio);
     update();

--- a/src/kicad/viewer/kicadfont.cpp
+++ b/src/kicad/viewer/kicadfont.cpp
@@ -53,7 +53,7 @@ double KicadFont::textWidth(const QString &text) const
     return width;
 }
 
-QFont KicadFont::font()
+QFont KicadFont::font() const
 {
     return _font;
 }

--- a/src/kicad/viewer/kicadfont.h
+++ b/src/kicad/viewer/kicadfont.h
@@ -35,7 +35,7 @@ public:
     double charWidth(QChar c) const;
     double textWidth(const QString &text) const;
 
-    QFont font();
+    QFont font() const;
     static QFont font(double size);
     void drawText(QPainter *painter, const QRectF &rect, int flags, const QString &text) const;
 


### PR DESCRIPTION
This replaces all instances of direction/setDirection with angle/setAngle for the DrawText type. Internally a QTransform is also stored so that the transform matrix doesn't have to be continually recalculated on every paint event.  This also more closely matches the KiCAD file format which also uses a numerical value for the angle.

Testing is needed before merging.