### PR TITLE
Safety/Initialization/Deletion fixes.

### DIFF
--- a/src/kicad/itemmodel/componentlibitemmodel.cpp
+++ b/src/kicad/itemmodel/componentlibitemmodel.cpp
@@ -22,18 +22,17 @@
 #include <QFont>
 
 ComponentLibItemModel::ComponentLibItemModel(Lib *lib, QObject *parent)
-    : QAbstractItemModel(parent)
+    : QAbstractItemModel(parent),
+      _lib(nullptr),
+      _activeComponent(nullptr),
+      _selectedMode(false)
 {
-    if (lib != nullptr)
+    if (lib == nullptr)
     {
-        _lib = lib;
+        lib = new Lib();
     }
-    else
-    {
-        _lib = new Lib();
-    }
-    _selectedMode = false;
-    _activeComponent = nullptr;
+
+    _lib = lib;
 }
 
 Lib *ComponentLibItemModel::lib() const
@@ -47,7 +46,10 @@ void ComponentLibItemModel::setLib(Lib *lib)
     _activeComponent = nullptr;
     beginResetModel();
     resetInternalData();
-    // delete _lib;
+    if(lib != nullptr)
+    {
+       delete _lib;
+    }
     _lib = lib;
     endResetModel();
     emit layoutChanged();

--- a/src/kicad/itemmodel/componentlibtreeview.cpp
+++ b/src/kicad/itemmodel/componentlibtreeview.cpp
@@ -24,16 +24,18 @@
 #include <QMouseEvent>
 
 ComponentLibTreeView::ComponentLibTreeView(Lib *lib, QWidget *parent)
-    : QTreeView(parent)
+    : QTreeView(parent),
+      _model(nullptr),
+      _sortProxy(nullptr),
+      _editMode(false),
+      _removeAction(nullptr)
 {
-    if (lib != nullptr)
+    if (lib == nullptr)
     {
-        _model = new ComponentLibItemModel(lib);
+        lib = new Lib();
     }
-    else
-    {
-        _model = new ComponentLibItemModel(new Lib());
-    }
+
+    _model = new ComponentLibItemModel(lib);
 
     setSelectionMode(QAbstractItemView::ExtendedSelection);
     _editMode = false;

--- a/src/kicad/itemmodel/componentpinsitemmodel.cpp
+++ b/src/kicad/itemmodel/componentpinsitemmodel.cpp
@@ -24,11 +24,12 @@
 #include <QDebug>
 
 ComponentPinsItemModel::ComponentPinsItemModel(Component *component, QObject *parent)
-    : QAbstractItemModel(parent)
+    : QAbstractItemModel(parent),
+      _component(nullptr),
+      _isExpendable(true)
 {
     setComponent(component);
-    _isExpendable = true;
-    _higherPin = QString();
+    _higherPin.clear();
 }
 
 Component *ComponentPinsItemModel::component() const
@@ -317,8 +318,8 @@ QString ComponentPinsItemModel::toNumeric(const QString &str)
 
 void ComponentPinsItemModel::updateHigherPin()
 {
-    _higherPin = QString();
-    QString higherNumPin = QString();
+    QString higherNumPin;
+    _higherPin.clear();
     if (_component != nullptr)
     {
         for (Pin *pin : _component->pins())

--- a/src/kicad/itemmodel/componentpinstableview.cpp
+++ b/src/kicad/itemmodel/componentpinstableview.cpp
@@ -25,7 +25,12 @@
 #include <QMouseEvent>
 
 ComponentPinsTableView::ComponentPinsTableView(Component *component, QWidget *parent)
-    : QTableView(parent)
+    : QTableView(parent),
+      _model(nullptr),
+      _delegate(nullptr),
+      _sortProxy(nullptr),
+      _removeAction(nullptr),
+      _copyAction(nullptr)
 {
     _model = new ComponentPinsItemModel(component);
 

--- a/src/kicad/itemmodel/pinlisteditor.cpp
+++ b/src/kicad/itemmodel/pinlisteditor.cpp
@@ -22,7 +22,9 @@
 #include <QVBoxLayout>
 
 PinListEditor::PinListEditor(QWidget *parent)
-    : QWidget(parent)
+    : QWidget(parent),
+      _componentPinsTableView(nullptr),
+      _nameFilterEdit(nullptr)
 {
     createWidgets();
 }

--- a/src/kicad/ksseditor/ksseditor.cpp
+++ b/src/kicad/ksseditor/ksseditor.cpp
@@ -22,7 +22,10 @@
 #include <QPainter>
 
 KssEditor::KssEditor(QWidget *parent)
-    : QPlainTextEdit(parent)
+    : QPlainTextEdit(parent),
+      _syntax(nullptr),
+      _kssEditorMargin(nullptr),
+      _lineError(-1)
 {
     _syntax = new KSSSyntax(this->document());
 
@@ -36,7 +39,6 @@ KssEditor::KssEditor(QWidget *parent)
     font.setStyleHint(QFont::Monospace);
     setFont(font);
 
-    _lineError = -1;
     updateExtraSelection();
 }
 

--- a/src/kicad/model/component.cpp
+++ b/src/kicad/model/component.cpp
@@ -29,11 +29,15 @@
  * @param name optionally specify the component name at the creation
  */
 Component::Component(const QString &name)
-    : _prefix("U")
+    : _prefix("U"),
+      _showPinName(true),
+      _showPadName(true),
+      _unitCount(1),
+      _refText(nullptr),
+      _nameText(nullptr),
+      _packageText(nullptr),
+      _docText(nullptr)
 {
-    _showPinName = true;
-    _showPadName = true;
-    _unitCount = 1;
     _refText = new DrawText("U");
     _nameText = new DrawText();
     _packageText = new DrawText();
@@ -80,15 +84,24 @@ Component::~Component()
     for (auto &pin : _pins)
     {
         delete pin;
+        pin = nullptr;
     }
     for (auto &draw : _draws)
     {
         delete draw;
+        draw = nullptr;
     }
     delete _refText;
+    _refText = nullptr;
+
     delete _nameText;
+    _nameText = nullptr;
+
     delete _packageText;
+    _packageText = nullptr;
+
     delete _docText;
+    _docText = nullptr;
 }
 
 /**
@@ -149,6 +162,7 @@ void Component::removePin(Pin *pin)
     if (_pins.removeOne(pin))
     {
         delete pin;
+        pin = nullptr;
     }
 }
 
@@ -160,6 +174,7 @@ void Component::clearPins()
     for (auto &pin : _pins)
     {
         delete pin;
+        pin = nullptr;
     }
     _pins.clear();
 }
@@ -211,6 +226,7 @@ void Component::removeDraw(Draw *draw)
     if (_draws.removeOne(draw))
     {
         delete draw;
+        draw = nullptr;
     }
 }
 
@@ -222,6 +238,7 @@ void Component::clearDraws()
     for (auto &draw : _draws)
     {
         delete draw;
+        draw = nullptr;
     }
     _draws.clear();
 }

--- a/src/kicad/model/drawarc.cpp
+++ b/src/kicad/model/drawarc.cpp
@@ -19,6 +19,9 @@
 #include "drawarc.h"
 
 DrawArc::DrawArc()
+    : _radius(0),
+      _startAngle(0),
+      _endAngle(0)
 {
 }
 

--- a/src/kicad/model/drawcircle.cpp
+++ b/src/kicad/model/drawcircle.cpp
@@ -19,6 +19,7 @@
 #include "drawcircle.h"
 
 DrawCircle::DrawCircle()
+    : _radius(0)
 {
 }
 

--- a/src/kicad/model/lib.cpp
+++ b/src/kicad/model/lib.cpp
@@ -124,6 +124,7 @@ void Lib::removeComponent(Component *component)
     if (_components.removeOne(component))
     {
         delete component;
+        component = nullptr;
     }
 }
 
@@ -153,6 +154,7 @@ void Lib::clear()
     for (auto &component : _components)
     {
         delete component;
+        component = nullptr;
     }
     _components.clear();
 }

--- a/src/kicad/model/pad.cpp
+++ b/src/kicad/model/pad.cpp
@@ -21,7 +21,11 @@
 #include <QDebug>
 
 Pad::Pad()
-    : _angle(0)
+    : _shape(Pad::Rect),
+      _angle(0.0),
+      _drillDiameter(0.0),
+      _type(Pad::Std),
+      _layers(0)
 {
 }
 
@@ -118,7 +122,7 @@ Pad::Type Pad::type() const
 
 QString Pad::typeString() const
 {
-    switch (_shape)
+    switch (_type)
     {
         case Pad::Std:
             return "STD";

--- a/src/kicad/model/pin.cpp
+++ b/src/kicad/model/pin.cpp
@@ -22,7 +22,7 @@
 
 Pin::Pin()
     : _pinType(Pin::Normal),
-      _electricalType(Pin::Input)
+      _electricalType(Pin::Unspecified)
 {
     _angle = 0;
     _unit = 1;
@@ -36,7 +36,7 @@ Pin::Pin(const QString &name, const QString &padName)
     : _name(name),
       _padName(padName),
       _pinType(Pin::Normal),
-      _electricalType(Pin::Input)
+      _electricalType(Pin::Unspecified)
 {
     _angle = 0;
     _unit = 1;

--- a/src/kicad/parser/kicadlibparser.cpp
+++ b/src/kicad/parser/kicadlibparser.cpp
@@ -47,6 +47,7 @@ Lib *KicadLibParser::loadLib(const QString &fileName, Lib *lib)
         if (mylib)
         {
             delete lib;
+            lib = nullptr;
         }
         return nullptr;
     }
@@ -55,7 +56,7 @@ Lib *KicadLibParser::loadLib(const QString &fileName, Lib *lib)
     _stream.readLine();
     lib->clear();
 
-    Component *component;
+    Component *component = nullptr;
     do
     {
         component = readComponent();
@@ -241,8 +242,8 @@ void KicadLibParser::writePin(Pin *pin)
 
 void KicadLibParser::writeDraw(Draw *draw)
 {
-    DrawRect *drawRect;
-    DrawText *drawText;
+    DrawRect *drawRect = nullptr;
+    DrawText *drawText = nullptr;
 
     switch (draw->type())
     {
@@ -566,6 +567,7 @@ Component *KicadLibParser::readComponent()
     } while (!_stream.atEnd());
 
     delete component;
+    component = nullptr;
     return nullptr;
 }
 
@@ -584,6 +586,7 @@ Pin *KicadLibParser::readPin()
     if (_stream.status() != QTextStream::Ok)
     {
         delete pin;
+        pin = nullptr;
         return nullptr;
     }
     pin->setName(name);
@@ -594,51 +597,55 @@ Pin *KicadLibParser::readPin()
     if (_stream.status() != QTextStream::Ok)
     {
         delete pin;
+        pin = nullptr;
         return nullptr;
     }
     pin->setPadName(padName);
 
     // position
-    int x;
-    int y;
+    int x = 0;
+    int y = 0;
     _stream >> x >> y;
     if (_stream.status() != QTextStream::Ok)
     {
         delete pin;
+        pin = nullptr;
         return nullptr;
     }
     pin->setPos(x, -y);
 
     // lenght
-    int lenght;
+    int lenght = 0;
     _stream >> lenght;
     if (_stream.status() != QTextStream::Ok)
     {
         delete pin;
+        pin = nullptr;
         return nullptr;
     }
     pin->setLength(lenght);
 
     // orientation
-    char directionChar;
+    char directionChar = 0;
     _stream.skipWhiteSpace();
     _stream >> directionChar;
     pin->setAngle(pinAngle(directionChar));
 
     // text size
-    int textNameSize;
-    int textPadSize;
+    int textNameSize = 0;
+    int textPadSize = 0;
     _stream >> textPadSize;
     _stream >> textNameSize;
     pin->setTextNameSize(textNameSize);
     pin->setTextPadSize(textPadSize);
 
     // layer
-    int layer;
+    int layer = 0;
     _stream >> layer;
     if (_stream.status() != QTextStream::Ok)
     {
         delete pin;
+        pin = nullptr;
         return nullptr;
     }
     pin->setUnit(layer);
@@ -662,8 +669,8 @@ Pin *KicadLibParser::readPin()
 
 Draw *KicadLibParser::readDraw(char c)
 {
-    int n;
-    char nc;
+    int n = 0;
+    char nc = 0;
     QString text;
     _stream.resetStatus();
 
@@ -1016,7 +1023,7 @@ QString KicadLibParser::pinElectricalTypeString(Pin::ElectricalType electricalTy
 
 int KicadLibParser::pinAngle(char directionChar)
 {
-    int angle;
+    int angle = 0;
     switch (directionChar)
     {
         default:
@@ -1084,7 +1091,7 @@ Pin::PinType KicadLibParser::pinType(const QString &pinTypeString) const
 
 Pin::ElectricalType KicadLibParser::pinElectricalType(char electricalTypeChar) const
 {
-    Pin::ElectricalType electricalType;
+    Pin::ElectricalType electricalType = Pin::NotConnected;
     switch (electricalTypeChar)
     {
         case 'I':

--- a/src/kicad/pinruler/classrule.cpp
+++ b/src/kicad/pinruler/classrule.cpp
@@ -45,31 +45,30 @@ QStringList ClassRule::boolEnumStr = QStringList() << "false"
                                                    << "true";
 
 ClassRule::ClassRule(const QString &selector)
-    : Rule(selector)
+    : Rule(selector),
+      _position(PositionASide),
+      _positionSet(false),
+
+      _sort(SortAsc),
+      _sortSet(false),
+
+      _sortPattern(".*"),
+      _sortPatternSet(false),
+
+      _length(200),
+      _lengthSet(false),
+
+      _priority(0),
+      _prioritySet(false),
+
+      _visibility(VisibilityVisible),
+      _visibilitySet(false),
+
+      _labelSet(false),
+
+      _rect(0),
+      _rectSet(false)
 {
-    _position = PositionASide;
-    _positionSet = false;
-
-    _sort = SortAsc;
-    _sortSet = false;
-
-    _sortPattern = ".*";
-    _sortPatternSet = false;
-
-    _length = 200;
-    _lengthSet = false;
-
-    _priority = 0;
-    _prioritySet = false;
-
-    _visibility = VisibilityVisible;
-    _visibilitySet = false;
-
-    _label = "";
-    _labelSet = false;
-
-    _rect = 0;
-    _rectSet = false;
 }
 
 Rule::Type ClassRule::type() const

--- a/src/kicad/pinruler/pinclass.cpp
+++ b/src/kicad/pinruler/pinclass.cpp
@@ -25,9 +25,9 @@
 #include "viewer/kicadfont.h"
 
 PinClass::PinClass(QString className)
-    : _className(std::move(className))
+    : _className(std::move(className)),
+      _brect(false)
 {
-    _brect = false;
 }
 
 QString PinClass::className() const
@@ -193,7 +193,7 @@ void PinClass::setPos(const QPoint &basePos)
     QPoint pinPos = basePos;
     QPoint offset;
     QPoint translate;
-    int angle;
+    int angle = 0;
 
     switch (_position)
     {

--- a/src/kicad/pinruler/pinclassitem.cpp
+++ b/src/kicad/pinruler/pinclassitem.cpp
@@ -21,9 +21,9 @@
 #include <QCollator>
 
 PinClassItem::PinClassItem(Pin *pin)
-    : _pin(pin)
+    : _pin(pin),
+      _priority(0)
 {
-    _priority = 0;
 }
 
 Pin *PinClassItem::pin() const

--- a/src/kicad/pinruler/pinrule.cpp
+++ b/src/kicad/pinruler/pinrule.cpp
@@ -49,18 +49,19 @@ QStringList PinRule::pinTypeEnumStr = QStringList() << "norm"
                                                     << "nologic";
 
 PinRule::PinRule(const QString &selector)
-    : Rule(selector)
+    : Rule(selector),
+
+      _classSet(false),
+
+      _elecType(Pin::Input),
+      _elecTypeSet(false),
+
+      _pinType(Pin::Normal),
+      _pinTypeSet(false),
+
+      _priority(0),
+      _prioritySet(false)
 {
-    _classSet = false;
-
-    _elecType = Pin::Input;
-    _elecTypeSet = false;
-
-    _pinType = Pin::Normal;
-    _pinTypeSet = false;
-
-    _priority = 0;
-    _prioritySet = false;
 }
 
 Rule::Type PinRule::type() const

--- a/src/kicad/pinruler/pinruler.cpp
+++ b/src/kicad/pinruler/pinruler.cpp
@@ -24,8 +24,8 @@
 #include "model/drawrect.h"
 
 PinRuler::PinRuler(RulesSet *ruleSet)
+    : _ruleSet(ruleSet)
 {
-    _ruleSet = ruleSet;
 }
 
 bool nameGreaterThan(PinClass *c1, PinClass *c2)
@@ -53,8 +53,8 @@ bool prioGreaterThan(PinClass *c1, PinClass *c2)
 
 void PinRuler::organize(Component *component)
 {
-    int x;
-    int y;
+    int x = -1;
+    int y = -1;
 
     component->clearDraws();
 
@@ -340,6 +340,7 @@ void PinRuler::organize(Component *component)
     for (PinClass *mpinClass : _pinClasses)
     {
         delete mpinClass;
+        mpinClass = nullptr;
     }
     _pinClasses.clear();
 }
@@ -351,7 +352,10 @@ RulesSet *PinRuler::ruleSet() const
 
 void PinRuler::setRuleSet(RulesSet *ruleSet)
 {
-    delete _ruleSet;
+    if(_ruleSet != nullptr)
+    {
+        delete _ruleSet;
+    }
     _ruleSet = ruleSet;
 }
 

--- a/src/kicad/pinruler/rule.cpp
+++ b/src/kicad/pinruler/rule.cpp
@@ -21,9 +21,10 @@
 #include <QDebug>
 
 Rule::Rule(const QString &selector)
-    : _selector(selector, QRegularExpression::CaseInsensitiveOption)
+    : _selector(selector, QRegularExpression::CaseInsensitiveOption),
+      _enabled(true),
+      _line(-1)
 {
-    _enabled = true;
 }
 
 Rule::~Rule()

--- a/src/kicad/pinruler/rulesparser.cpp
+++ b/src/kicad/pinruler/rulesparser.cpp
@@ -25,8 +25,10 @@
 #include <QRegularExpression>
 
 RulesParser::RulesParser(const QString &fileName)
+    : _id(-1),
+      _line(-1),
+      _errorLine(-1)
 {
-    _errorLine = -1;
     _fileName = fileName;
     if (!fileName.isEmpty())
     {
@@ -82,6 +84,7 @@ bool RulesParser::parse(RulesSet *ruleSet)
         {
             _errorLine = _line;
             delete rule;
+            rule = nullptr;
             return false;  // error
         }
         QString propertyValue;
@@ -105,6 +108,7 @@ bool RulesParser::parse(RulesSet *ruleSet)
         {
             _errorLine = _line;
             delete rule;
+            rule = nullptr;
             return false;  // error
         }
 

--- a/src/kicad/pinruler/rulesset.cpp
+++ b/src/kicad/pinruler/rulesset.cpp
@@ -53,10 +53,12 @@ RulesSet::~RulesSet()
     for (auto &classRule : _classRules)
     {
         delete classRule;
+        classRule = nullptr;
     }
     for (auto &pinRule : _pinRules)
     {
         delete pinRule;
+        pinRule = nullptr;
     }
 }
 

--- a/src/kicad/schematicsimport/textimporter.cpp
+++ b/src/kicad/schematicsimport/textimporter.cpp
@@ -23,11 +23,11 @@
 #include <QFileInfo>
 
 TextImporter::TextImporter()
+    : _columnSeparator('\t'),
+      _pinColumn(0),
+      _pinNameColumnsSeparator('/')
 {
-    _columnSeparator = '\t';
-    _pinColumn = 0;
     _pinNameColumns = {1};
-    _pinNameColumnsSeparator = '/';
 }
 
 QChar TextImporter::columnSeparator() const

--- a/src/kicad/viewer/componentitem.cpp
+++ b/src/kicad/viewer/componentitem.cpp
@@ -28,9 +28,11 @@
 const int ComponentItem::ratio = 5;
 
 ComponentItem::ComponentItem(Component *component, int unit)
+    : _component(nullptr),
+      _unit(0),
+      _showElectricalType(true)
 {
     setComponent(component, unit);
-    _showElectricalType = true;
 }
 
 void ComponentItem::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget)

--- a/src/kicad/viewer/componentscene.cpp
+++ b/src/kicad/viewer/componentscene.cpp
@@ -22,12 +22,15 @@
 #include <QPrinter>
 
 ComponentScene::ComponentScene(qreal x, qreal y, qreal w, qreal h)
-    : QGraphicsScene(x, y, w, h)
-{
-    _grid = true;
-    _gridFront = false;
-    _prevGridSize = 0;
+    : QGraphicsScene(x, y, w, h),
 
+      _grid(true),
+      _gridFront(false),
+      _prevGridSize(0),
+      _elecType(false),
+      _component(nullptr),
+      _componentItem(nullptr)
+{
     setComponent(nullptr);
 }
 

--- a/src/kicad/viewer/componentviewer.cpp
+++ b/src/kicad/viewer/componentviewer.cpp
@@ -30,7 +30,9 @@
 #include <qmath.h>
 
 ComponentViewer::ComponentViewer(QWidget *parent)
-    : QGraphicsView(parent)
+    : QGraphicsView(parent),
+      _scene(nullptr),
+      _currentZoomLevel(0.0)
 {
     _scene = new ComponentScene(-5000, -5000, 10000, 10000);
     setScene(_scene);

--- a/src/kicad/viewer/componentwidget.cpp
+++ b/src/kicad/viewer/componentwidget.cpp
@@ -23,10 +23,17 @@
 #include <QLayout>
 
 ComponentWidget::ComponentWidget(QWidget *parent)
-    : QWidget(parent)
+    : QWidget(parent),
+      _component(nullptr),
+      _viewer(nullptr),
+      _gridGroup(nullptr),
+      _actionNoGrid(nullptr),
+      _actionGrid(nullptr),
+      _actionGridFront(nullptr),
+      _actionElecType(nullptr),
+      _comboUnit(nullptr)
 {
     Q_INIT_RESOURCE(imgviewer);
-    _component = nullptr;
     createWidgets();
 }
 

--- a/src/kicad/viewer/drawcircleitem.cpp
+++ b/src/kicad/viewer/drawcircleitem.cpp
@@ -24,7 +24,8 @@
 #include <QPainter>
 
 DrawCircleItem::DrawCircleItem(DrawCircle *draw)
-    : DrawItem(draw)
+    : DrawItem(draw),
+      _drawCircle(nullptr)
 {
     setDraw(draw);
     setZValue(-1);

--- a/src/kicad/viewer/drawitem.cpp
+++ b/src/kicad/viewer/drawitem.cpp
@@ -29,8 +29,8 @@
 #include "drawtextitem.h"
 
 DrawItem::DrawItem(Draw *draw)
+    : _draw(draw)
 {
-    _draw = draw;
     setZValue(-1);
 }
 

--- a/src/kicad/viewer/drawpolyitem.cpp
+++ b/src/kicad/viewer/drawpolyitem.cpp
@@ -24,7 +24,8 @@
 #include <QPainter>
 
 DrawPolyItem::DrawPolyItem(DrawPoly *draw)
-    : DrawItem(draw)
+    : DrawItem(draw),
+      _drawPoly(nullptr)
 {
     setDraw(draw);
     setZValue(-1);

--- a/src/kicad/viewer/drawrectitem.cpp
+++ b/src/kicad/viewer/drawrectitem.cpp
@@ -24,7 +24,8 @@
 #include <QPainter>
 
 DrawRectItem::DrawRectItem(DrawRect *draw)
-    : DrawItem(draw)
+    : DrawItem(draw),
+      _drawRect(nullptr)
 {
     setDraw(draw);
     setZValue(-1);

--- a/src/kicad/viewer/drawtextitem.cpp
+++ b/src/kicad/viewer/drawtextitem.cpp
@@ -25,22 +25,33 @@
 
 DrawTextItem::DrawTextItem(DrawText *draw, bool internal)
     : DrawItem(draw),
+      _drawText(nullptr),
+      _fontText(nullptr),
       _internal(internal)
 {
-    _fontText = nullptr;
     setDraw(draw);
     setZValue(10);
 }
 
 DrawTextItem::~DrawTextItem()
 {
-    delete _fontText;
+    deleteFontText();
+}
+
+void DrawTextItem::deleteFontText()
+{
+    if(_fontText != nullptr)
+    {
+        delete _fontText;
+        _fontText = nullptr;
+    }
 }
 
 void DrawTextItem::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget)
 {
     Q_UNUSED(option)
     Q_UNUSED(widget)
+    Q_ASSERT(_fontText != nullptr);
 
     painter->setRenderHint(QPainter::Antialiasing);
     painter->setRenderHint(QPainter::TextAntialiasing);
@@ -81,7 +92,7 @@ void DrawTextItem::setDraw(DrawText *draw)
 {
     _drawText = draw;
 
-    delete _fontText;
+    deleteFontText();
     _fontText = new KicadFont(_drawText->textSize() / ComponentItem::ratio);
 
     QFont font = _fontText->font();

--- a/src/kicad/viewer/drawtextitem.h
+++ b/src/kicad/viewer/drawtextitem.h
@@ -47,6 +47,9 @@ public:
     void setDraw(DrawText *draw);
 
 protected:
+    void deleteFontText();
+
+protected:
     DrawText *_drawText;
     QRectF _rect;
     QRectF _textRect;

--- a/src/kicad/viewer/kicadfont.cpp
+++ b/src/kicad/viewer/kicadfont.cpp
@@ -30,6 +30,7 @@ const int KicadFont::charWidthTable[] = {35, 20, 28, 38, 35, 42, 45, 20, 26, 26,
                                          34, 20, 20, 30, 22, 48, 34, 34, 34, 33, 25, 30, 23, 34, 29, 39, 31, 29, 31, 26, 35, 26};
 
 KicadFont::KicadFont(double size)
+    : _size(0.0)
 {
     setSize(size);
 }
@@ -45,7 +46,7 @@ double KicadFont::charWidth(QChar c) const
 
 double KicadFont::textWidth(const QString &text) const
 {
-    double width = 0;
+    double width = 0.0;
     for (QChar c : text)
     {
         width += charWidth(c);

--- a/src/kicad/viewer/pinitem.cpp
+++ b/src/kicad/viewer/pinitem.cpp
@@ -27,11 +27,12 @@
 #include "model/component.h"
 
 PinItem::PinItem(Pin *pin)
+    : _pin(nullptr),
+      _fontPad(nullptr),
+      _fontName(nullptr),
+      _fontType(nullptr),
+      _showElectricalType(false)
 {
-    _fontPad = nullptr;
-    _fontName = nullptr;
-    _fontType = nullptr;
-
     setPin(pin);
     setFlag(QGraphicsItem::ItemIsSelectable);
     setCursor(Qt::CrossCursor);
@@ -40,9 +41,21 @@ PinItem::PinItem(Pin *pin)
 
 PinItem::~PinItem()
 {
-    delete _fontPad;
-    delete _fontName;
-    delete _fontType;
+    if(_fontPad != nullptr)
+    {
+        delete _fontPad;
+        _fontPad = nullptr;
+    }
+    if(_fontName != nullptr)
+    {
+        delete _fontName;
+        _fontName = nullptr;
+    }
+    if(_fontType != nullptr)
+    {
+      delete _fontType;
+      _fontType = nullptr;
+    }
 }
 
 void PinItem::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget)
@@ -299,13 +312,18 @@ void PinItem::setPin(Pin *pin)
     QString type = Pin::electricalTypeDesc(_pin->electricalType());
     type[0] = type[0].toUpper();
 
-    delete _fontPad;
+    if(_fontPad != nullptr)
+        delete _fontPad;
     _fontPad = new KicadFont(_pin->textPadSize() / ComponentItem::ratio);
     QFontMetrics metricsPad(_fontPad->font());
-    delete _fontName;
+
+    if(_fontName != nullptr)
+        delete _fontName;
     _fontName = new KicadFont(_pin->textNameSize() / ComponentItem::ratio);
     QFontMetrics metricsName(_fontName->font());
-    delete _fontType;
+
+    if(_fontType != nullptr)
+        delete _fontType;
     _fontType = new KicadFont(25.0 / ComponentItem::ratio);
     QFontMetrics metricsType(_fontType->font());
 

--- a/src/pdf_extract/controller/pdfloader.cpp
+++ b/src/pdf_extract/controller/pdfloader.cpp
@@ -24,7 +24,8 @@
 #include <QDebug>
 
 PDFLoader::PDFLoader(PDFDatasheet *pdfDatasheet)
-    : _pdfDatasheet(pdfDatasheet)
+    : _document(nullptr),
+      _pdfDatasheet(pdfDatasheet)
 {
     _document = Poppler::Document::load(_pdfDatasheet->_fileName);
     _pdfDatasheet->_pageCount = _document->numPages();
@@ -37,7 +38,11 @@ PDFLoader::PDFLoader(PDFDatasheet *pdfDatasheet)
 
 PDFLoader::~PDFLoader()
 {
-    delete _document;
+    if(_document != nullptr)
+    {
+      delete _document;
+      _document = nullptr;
+    }
 }
 
 bool PDFLoader::loadPage(PDFPage *pdfPage)
@@ -126,6 +131,7 @@ void PDFLoader::loadBoxes(PDFPage *pdfPage)
             }
         }
         delete ptextBox;
+        ptextBox = nullptr;
     }
     pdfPage->_boxesLoaded = true;
 }

--- a/src/pdf_extract/datasheet.cpp
+++ b/src/pdf_extract/datasheet.cpp
@@ -32,10 +32,10 @@
 using namespace Poppler;
 
 Datasheet::Datasheet()
+    : _doc(nullptr),
+      _debug(false),
+      _force(false)
 {
-    _doc = nullptr;
-    _debug = false;
-    _force = false;
 }
 
 Datasheet::~Datasheet()
@@ -74,8 +74,11 @@ bool Datasheet::open(const QString &fileName)
 
 void Datasheet::close()
 {
-    delete _doc;
-    _doc = nullptr;
+    if(_doc != nullptr)
+    {
+      delete _doc;
+      _doc = nullptr;
+    }
 }
 
 void Datasheet::pinSearch(int numPage)
@@ -216,6 +219,7 @@ void Datasheet::pinSearch(int numPage)
         {
             badcount++;
             delete package;
+            package = nullptr;
             continue;
         }
         // package pin 1 very far to pin 2 are deleted
@@ -224,6 +228,7 @@ void Datasheet::pinSearch(int numPage)
         {
             badcount++;
             delete package;
+            package = nullptr;
             continue;
         }
         count++;
@@ -420,7 +425,11 @@ QList<DatasheetPin *> Datasheet::extractPins(int numPage)
                 else if (box->text.size() > 10 && (!box->text.contains("/") && !box->text.contains("_") && !box->text.contains(",")))
                 {
                     // qDebug()<<"filter long label"<<box->text;
-                    delete box;
+                    if(box != nullptr)
+                    {
+                        delete box;
+                        box = nullptr;
+                    }
                     box = new DatasheetBox();
                     box->page = numPage;
                 }
@@ -434,6 +443,7 @@ QList<DatasheetPin *> Datasheet::extractPins(int numPage)
             prev = false;
         }
         delete textBox;
+        textBox = nullptr;
     }
 
     // pairing label and number to pin
@@ -493,6 +503,7 @@ QList<DatasheetPin *> Datasheet::extractPins(int numPage)
     }
 
     delete page;
+    page = nullptr;
     return pins;
 }
 
@@ -558,6 +569,7 @@ void Datasheet::clean()
     for (DatasheetPackage *box : _packages)
     {
         delete box;
+        box = nullptr;
     }
     _packages.clear();
 }
@@ -646,14 +658,18 @@ int Datasheet::pagePinDiagram(int pageStart, int pageEnd, bool *bgaStyle)
                 }
             }
             delete textBox;
+            textBox = nullptr;
 
             if (labelOk && (vssOk || vddOk))
             {
                 delete page;
+                page = nullptr;
                 return i;
             }
         }
         delete page;
+        page = nullptr;
+
         QCoreApplication::processEvents();
     }
 

--- a/src/pdf_extract/datasheetbox.h
+++ b/src/pdf_extract/datasheetbox.h
@@ -46,7 +46,6 @@ public:
     static bool isAlign(const DatasheetBox &label, const DatasheetBox &number);
 
     static int created;
-    static int deleted;
 };
 
 #endif  // DATASHEETBOX_H

--- a/src/pdf_extract/datasheetpin.cpp
+++ b/src/pdf_extract/datasheetpin.cpp
@@ -19,13 +19,23 @@
 #include "datasheetpin.h"
 
 DatasheetPin::DatasheetPin()
+    : numberBox(nullptr),
+      nameBox(nullptr)
 {
 }
 
 DatasheetPin::~DatasheetPin()
 {
-    delete numberBox;
-    delete nameBox;
+    if(numberBox != nullptr)
+    {
+        delete numberBox;
+        numberBox = nullptr;
+    }
+    if(nameBox != nullptr)
+    {
+        delete nameBox;
+        nameBox = nullptr;
+    }
 }
 
 qreal DatasheetPin::distanceToPoint(const QPointF &center) const

--- a/src/pdf_extract/model/pdfdatasheet.cpp
+++ b/src/pdf_extract/model/pdfdatasheet.cpp
@@ -23,14 +23,20 @@
 #include "controller/pdfloader.h"
 
 PDFDatasheet::PDFDatasheet(QString fileName)
-    : _fileName(std::move(fileName))
+    : _pageCount(0),
+      _fileName(std::move(fileName)),
+      _pdfLoader(nullptr)
 {
     _pdfLoader = new PDFLoader(this);
 }
 
 PDFDatasheet::~PDFDatasheet()
 {
+  if(_pdfLoader != nullptr)
+  {
     delete _pdfLoader;
+    _pdfLoader = nullptr;
+  }
 }
 
 const QString &PDFDatasheet::fileName() const

--- a/src/pdf_extract/model/pdfpage.cpp
+++ b/src/pdf_extract/model/pdfpage.cpp
@@ -35,8 +35,10 @@ PDFPage::~PDFPage()
     for (PDFTextBox *textBox : _textBoxes)
     {
         delete textBox;
+        textBox = nullptr;
     }
     delete _page;
+    _page = nullptr;
 }
 
 PDFDatasheet *PDFPage::datasheet() const

--- a/src/pdf_extract/model/pdftextbox.cpp
+++ b/src/pdf_extract/model/pdftextbox.cpp
@@ -22,11 +22,11 @@
 
 PDFTextBox::PDFTextBox(QString text, const QRectF &boundingRect)
     : _text(std::move(text)),
-      _boundingRect(boundingRect)
+      _boundingRect(boundingRect),
+      _type(Text),
+      _page(nullptr),
+      _parentBox(nullptr)
 {
-    _page = nullptr;
-    _parentBox = nullptr;
-    _type = Text;
 }
 
 PDFTextBox::~PDFTextBox()
@@ -54,7 +54,7 @@ const QRectF &PDFTextBox::boundingRect() const
 
 bool PDFTextBox::isPadName() const
 {
-    bool okNumber;
+    bool okNumber = false;
     _text.toInt(&okNumber);
     if (okNumber)
     {

--- a/src/pdf_extract/pdfdebugwidget/pdfdebugitempage.cpp
+++ b/src/pdf_extract/pdfdebugwidget/pdfdebugitempage.cpp
@@ -28,9 +28,8 @@
 #include "pdfdebugitemtextbox.h"
 
 PdfDebugItemPage::PdfDebugItemPage(PDFPage *page)
+    : _page(page)
 {
-    _page = page;
-
     for (PDFTextBox *textBox : _page->textBoxes())
     {
         new PdfDebugItemTextBox(textBox, this);

--- a/src/pdf_extract/pdfdebugwidget/pdfdebugviewer.cpp
+++ b/src/pdf_extract/pdfdebugwidget/pdfdebugviewer.cpp
@@ -22,7 +22,8 @@
 #include <qmath.h>
 
 PdfDebugViewer::PdfDebugViewer(QWidget *parent)
-    : QGraphicsView(parent)
+    : QGraphicsView(parent),
+      _page(nullptr)
 {
     setScene(new QGraphicsScene(this));
 

--- a/src/pdf_extract/pdfdebugwidget/pdfdebugwidget.cpp
+++ b/src/pdf_extract/pdfdebugwidget/pdfdebugwidget.cpp
@@ -24,16 +24,27 @@
 
 PdfDebugWidget::PdfDebugWidget(QWidget *parent)
     : QWidget(parent),
-      _datasheet(nullptr)
+      _datasheet(nullptr),
+      _currentPage(nullptr),
+      _viewer(nullptr),
+      _ationPrev(nullptr),
+      _ationNext(nullptr),
+      _pageLineEdit(nullptr),
+      _pageLabel(nullptr)
 {
-    _currentPage = nullptr;
     createWidgets();
 }
 
 PdfDebugWidget::PdfDebugWidget(PDFDatasheet *datasheet, QWidget *parent)
-    : QWidget(parent)
+    : QWidget(parent),
+      _datasheet(nullptr),
+      _currentPage(nullptr),
+      _viewer(nullptr),
+      _ationPrev(nullptr),
+      _ationNext(nullptr),
+      _pageLineEdit(nullptr),
+      _pageLabel(nullptr)
 {
-    _currentPage = nullptr;
     createWidgets();
     setDatasheet(datasheet);
 }

--- a/src/uconfig_gui/componentinfoseditor.cpp
+++ b/src/uconfig_gui/componentinfoseditor.cpp
@@ -21,8 +21,13 @@
 #include <QFormLayout>
 
 ComponentInfosEditor::ComponentInfosEditor(UConfigProject *project)
+    : _project(project),
+      _component(nullptr),
+      _nameEdit(nullptr),
+      _packageEdit(nullptr),
+      _referenceEdit(nullptr),
+      _aliasesEdit(nullptr)
 {
-    _project = project;
     createWidgets();
     setComponent(nullptr);
 }

--- a/src/uconfig_gui/importer/componentspage.cpp
+++ b/src/uconfig_gui/importer/componentspage.cpp
@@ -29,7 +29,11 @@
 #include <kicad/schematicsimport/textimporter.h>
 
 ComponentsPage::ComponentsPage()
-    : QWizardPage(nullptr)
+    : QWizardPage(nullptr),
+      _checkAllBox(nullptr),
+      _statusLabel(nullptr),
+      _componentTreeView(nullptr),
+      _lib(nullptr)
 {
     QVBoxLayout *layout = new QVBoxLayout;
 
@@ -59,6 +63,10 @@ void ComponentsPage::initializePage()
     _lib = new Lib();
     switch (type)
     {
+        case PinListImporter::Undefined:
+            qFatal("not a valid type");
+            break;
+
         case PinListImporter::Kicad:
         {
             QString file = field("file").toString();
@@ -120,7 +128,12 @@ bool ComponentsPage::validatePage()
         _lib->takeComponent(component);
     }
     _componentTreeView->setLib(nullptr);
-    delete _lib;
+
+    if(_lib != nullptr)
+    {
+        delete _lib;
+        _lib = nullptr;
+    }
 
     return true;
 }

--- a/src/uconfig_gui/importer/datasheetprocesspage.cpp
+++ b/src/uconfig_gui/importer/datasheetprocesspage.cpp
@@ -26,7 +26,16 @@
 #include "pinlistimporter.h"
 
 DatasheetProcessPage::DatasheetProcessPage()
-    : QWizardPage(nullptr)
+    : QWizardPage(nullptr),
+      _datasheet(nullptr),
+      _thread(nullptr),
+      _statusLabel(nullptr),
+      _progressLabel(nullptr),
+      _progressBar(nullptr),
+      _logger(nullptr),
+      _pageStart(0),
+      _pageCount(0),
+      _complete(false)
 {
     QVBoxLayout *layout = new QVBoxLayout;
 

--- a/src/uconfig_gui/importer/datasheetthread.cpp
+++ b/src/uconfig_gui/importer/datasheetthread.cpp
@@ -21,11 +21,11 @@
 #include <QDebug>
 
 DataSheetThread::DataSheetThread(Datasheet *datasheet)
+    : _datasheet(datasheet),
+      _pageBegin(-1),
+      _pageEnd(-1)
 {
-    _datasheet = datasheet;
     _datasheet->moveToThread(this);
-    _pageBegin = -1;
-    _pageEnd = -1;
 }
 
 DataSheetThread::~DataSheetThread()
@@ -36,6 +36,7 @@ DataSheetThread::~DataSheetThread()
         terminate();
     }
     delete _datasheet;
+    _datasheet = nullptr;
 }
 
 bool DataSheetThread::open(const QString &fileName)

--- a/src/uconfig_gui/importer/filepage.cpp
+++ b/src/uconfig_gui/importer/filepage.cpp
@@ -33,10 +33,10 @@
 #include "pinlistimporter.h"
 
 FilePage::FilePage()
-    : QWizardPage(nullptr)
+    : QWizardPage(nullptr),
+      _complete(false),
+      _fileEdit(nullptr)
 {
-    _complete = false;
-
     setAcceptDrops(true);
 
     QLabel *label = new QLabel("File:");
@@ -66,6 +66,9 @@ int FilePage::nextId() const
 {
     switch (dynamic_cast<PinListImporter *>(wizard())->type())
     {
+        case PinListImporter::Undefined:
+            qFatal("not a valid type");
+            break;
         case PinListImporter::Kicad:
             return PinListImporter::PageComponents;
         case PinListImporter::CSV:
@@ -84,6 +87,9 @@ void FilePage::initializePage()
 {
     switch (dynamic_cast<PinListImporter *>(wizard())->type())
     {
+        case PinListImporter::Undefined:
+            qFatal("not a valid type");
+            break;
         case PinListImporter::Kicad:
             _fileTitle = "Kicad lib (.lib)";
             _suffixes << "lib";

--- a/src/uconfig_gui/importer/pdffilepage.cpp
+++ b/src/uconfig_gui/importer/pdffilepage.cpp
@@ -29,7 +29,14 @@
 
 PDFFilePage::PDFFilePage(DataSheetThread *datasheetThread)
     : QWizardPage(nullptr),
-      _datasheetThread(datasheetThread)
+      _datasheetThread(datasheetThread),
+      _complete(false),
+      _pagePreviewLabel(nullptr),
+      _allRadio(nullptr),
+      _partialRadio(nullptr),
+      _rangeEdit(nullptr),
+      _forceCheckBox(nullptr),
+      _pageCountLabel(nullptr)
 {
     _complete = false;
 

--- a/src/uconfig_gui/importer/pinlistimporter.cpp
+++ b/src/uconfig_gui/importer/pinlistimporter.cpp
@@ -28,7 +28,8 @@
 #include <QAbstractButton>
 
 PinListImporter::PinListImporter(const QString &fileName, QWidget *parent)
-    : QWizard(parent)
+    : QWizard(parent),
+      _type(Undefined)
 {
     setPage(PageStart, new StartWizardPage());
     setPage(PageFile, new FilePage());

--- a/src/uconfig_gui/importer/pinlistimporter.h
+++ b/src/uconfig_gui/importer/pinlistimporter.h
@@ -38,6 +38,7 @@ public:
      */
     enum ImportType
     {
+        Undefined = 0,
         CSV,
         PDF,
         // Table,

--- a/src/uconfig_gui/importer/resultspage.cpp
+++ b/src/uconfig_gui/importer/resultspage.cpp
@@ -28,7 +28,8 @@
 #include "pinlistimporter.h"
 
 ResultsPage::ResultsPage()
-    : QWizardPage(nullptr)
+    : QWizardPage(nullptr),
+      _resultLabel(nullptr)
 {
     QVBoxLayout *layout = new QVBoxLayout;
     _resultLabel = new QLabel();

--- a/src/uconfig_gui/importer/startwizardpage.cpp
+++ b/src/uconfig_gui/importer/startwizardpage.cpp
@@ -28,9 +28,9 @@
 #include "pinlistimporter.h"
 
 StartWizardPage::StartWizardPage(QWidget *parent)
-    : QWizardPage(parent)
+    : QWizardPage(parent),
+      _complete(false)
 {
-    _complete = false;
     setAcceptDrops(true);
 
     setTitle("Choose import format");

--- a/src/uconfig_gui/project/uconfigproject.cpp
+++ b/src/uconfig_gui/project/uconfigproject.cpp
@@ -29,11 +29,12 @@
 const int UConfigProject::MaxOldProject = 8;
 
 UConfigProject::UConfigProject(QWidget *window)
+    : _lib(nullptr),
+      _activeComponent(nullptr),
+      _window(nullptr)
 {
     setWindow(window);
     readSettings();
-    _lib = nullptr;
-    _activeComponent = nullptr;
 }
 
 UConfigProject::~UConfigProject()
@@ -212,7 +213,7 @@ bool UConfigProject::closeLib()
     }
     int ret = QMessageBox::question(_window,
                                     tr("Saves lib?"),
-                                    tr("Do you want to save '%1' library? Modifications will be losted.").arg(_lib->name()),
+                                    tr("Do you want to save '%1' library? Modifications will be lost.").arg(_lib->name()),
                                     QMessageBox::Yes | QMessageBox::Default,
                                     QMessageBox::No,
                                     QMessageBox::Cancel);

--- a/src/uconfig_gui/uconfigmainwindow.cpp
+++ b/src/uconfig_gui/uconfigmainwindow.cpp
@@ -44,7 +44,18 @@
 #include "pinruler/rulesset.h"
 
 UConfigMainWindow::UConfigMainWindow(UConfigProject *project)
-    : _project(project)
+    : _project(project),
+      _splitter(nullptr),
+      _componentsTreeView(nullptr),
+      _componentInfosEditor(nullptr),
+      _pinListEditor(nullptr),
+      _componentWidget(nullptr),
+      _ruleComboBox(nullptr),
+      _pdfDebug(nullptr),
+      _splitterEditor(nullptr),
+      _kssEditor(nullptr),
+      _componentsListDock(nullptr),
+      _componentInfosDock(nullptr)
 {
     setWindowIcon(QIcon(":/icons/img/uConfig.ico"));
     createWidgets();


### PR DESCRIPTION
Many variables were not initialized or were initialized only after complex code
execution. Variables (especially pointers!!!) should ALWAYS be initialized at the
start of the constructor in order to avoid uninitialized values while debugging
code in the constructor.

Always assign deleted pointers to nullptr for extra safety.

I know it's against your style but I very much hope you adopt this style because
it will save you from finding yourself in "impossible" situations.