### PR TITLE
Fix include statements

### DIFF
--- a/src/autotest/tst_pdf_extract.cpp
+++ b/src/autotest/tst_pdf_extract.cpp
@@ -1,9 +1,9 @@
 #include <QCoreApplication>
 #include <QtTest>
 
-#include "datasheet.h"
+#include <datasheet.h>
 
-#include "model/lib.h"
+#include <model/lib.h>
 
 class PdfExtract : public QObject
 {

--- a/src/kicad/itemmodel/componentlibitemmodel.h
+++ b/src/kicad/itemmodel/componentlibitemmodel.h
@@ -22,7 +22,7 @@
 #include <QAbstractItemModel>
 #include <QtCore/qglobal.h>
 
-#include "model/lib.h"
+#include <model/lib.h>
 
 class KICAD_EXPORT ComponentLibItemModel : public QAbstractItemModel
 {

--- a/src/kicad/itemmodel/componentpinsitemmodel.h
+++ b/src/kicad/itemmodel/componentpinsitemmodel.h
@@ -21,7 +21,7 @@
 
 #include <QAbstractItemModel>
 
-#include "model/component.h"
+#include <model/component.h>
 
 class KICAD_EXPORT ComponentPinsItemModel : public QAbstractItemModel
 {

--- a/src/kicad/parser/abstractlibparser.h
+++ b/src/kicad/parser/abstractlibparser.h
@@ -21,7 +21,7 @@
 
 #include <QtCore/qglobal.h>
 
-#include "../model/lib.h"
+#include <model/lib.h>
 
 class KICAD_EXPORT AbstractLibParser
 {

--- a/src/kicad/parser/kicadlibparser.cpp
+++ b/src/kicad/parser/kicadlibparser.cpp
@@ -22,10 +22,10 @@
 #include <QDebug>
 #include <QFileInfo>
 
-#include "model/drawcircle.h"
-#include "model/drawpoly.h"
-#include "model/drawrect.h"
-#include "model/drawtext.h"
+#include <model/drawcircle.h>
+#include <model/drawpoly.h>
+#include <model/drawrect.h>
+#include <model/drawtext.h>
 
 KicadLibParser::KicadLibParser()
 {

--- a/src/kicad/pinruler/pinclass.cpp
+++ b/src/kicad/pinruler/pinclass.cpp
@@ -22,7 +22,7 @@
 #include <qmath.h>
 #include <utility>
 
-#include "viewer/kicadfont.h"
+#include <viewer/kicadfont.h>
 
 PinClass::PinClass(QString className)
     : _className(std::move(className))

--- a/src/kicad/pinruler/pinclass.h
+++ b/src/kicad/pinruler/pinclass.h
@@ -27,8 +27,8 @@
 #include "classrule.h"
 #include "pinclassitem.h"
 
-#include "model/drawrect.h"
-#include "model/drawtext.h"
+#include <model/drawrect.h>
+#include <model/drawtext.h>
 
 class KICAD_EXPORT PinClass : public ClassRule
 {

--- a/src/kicad/pinruler/pinclassitem.h
+++ b/src/kicad/pinruler/pinclassitem.h
@@ -21,7 +21,7 @@
 
 #include <QtCore/qglobal.h>
 
-#include "model/pin.h"
+#include <model/pin.h>
 
 class KICAD_EXPORT PinClassItem
 {

--- a/src/kicad/pinruler/pinrule.h
+++ b/src/kicad/pinruler/pinrule.h
@@ -23,7 +23,7 @@
 #include <QStringList>
 #include <QtCore/qglobal.h>
 
-#include "model/pin.h"
+#include <model/pin.h>
 #include "rule.h"
 
 class KICAD_EXPORT PinRule : public Rule

--- a/src/kicad/pinruler/pinruler.cpp
+++ b/src/kicad/pinruler/pinruler.cpp
@@ -21,7 +21,7 @@
 #include <QDebug>
 #include <qmath.h>
 
-#include "model/drawrect.h"
+#include <model/drawrect.h>
 
 PinRuler::PinRuler(RulesSet *ruleSet)
 {

--- a/src/kicad/pinruler/pinruler.h
+++ b/src/kicad/pinruler/pinruler.h
@@ -22,7 +22,7 @@
 #include <QString>
 #include <QtCore/qglobal.h>
 
-#include "model/component.h"
+#include <model/component.h>
 #include "pinclass.h"
 #include "rulesset.h"
 

--- a/src/kicad/schematicsimport/schematicsimporter.h
+++ b/src/kicad/schematicsimport/schematicsimporter.h
@@ -21,7 +21,7 @@
 
 #include <QtCore/qglobal.h>
 
-#include "model/component.h"
+#include <model/component.h>
 
 class KICAD_EXPORT SchematicsImporter
 {

--- a/src/kicad/viewer/componentitem.h
+++ b/src/kicad/viewer/componentitem.h
@@ -23,7 +23,7 @@
 #include <QMap>
 #include <QtCore/qglobal.h>
 
-#include "model/component.h"
+#include <model/component.h>
 #include "pinitem.h"
 
 class PinItem;

--- a/src/kicad/viewer/componentscene.h
+++ b/src/kicad/viewer/componentscene.h
@@ -23,7 +23,7 @@
 #include <QtCore/qglobal.h>
 
 #include "componentitem.h"
-#include "model/component.h"
+#include <model/component.h>
 
 class KICAD_EXPORT ComponentScene : public QGraphicsScene
 {

--- a/src/kicad/viewer/componentviewer.h
+++ b/src/kicad/viewer/componentviewer.h
@@ -24,7 +24,7 @@
 #include <QtCore/qglobal.h>
 
 #include "componentscene.h"
-#include "model/component.h"
+#include <model/component.h>
 
 class ComponentScene;
 class ComponentItem;

--- a/src/kicad/viewer/drawcircleitem.h
+++ b/src/kicad/viewer/drawcircleitem.h
@@ -23,7 +23,7 @@
 
 #include "drawitem.h"
 
-#include "model/drawcircle.h"
+#include <model/drawcircle.h>
 
 class KICAD_EXPORT DrawCircleItem : public DrawItem
 {

--- a/src/kicad/viewer/drawitem.h
+++ b/src/kicad/viewer/drawitem.h
@@ -22,7 +22,7 @@
 #include <QGraphicsItem>
 #include <QtCore/qglobal.h>
 
-#include "model/draw.h"
+#include <model/draw.h>
 
 class KICAD_EXPORT DrawItem : public QGraphicsItem
 {

--- a/src/kicad/viewer/drawpolyitem.h
+++ b/src/kicad/viewer/drawpolyitem.h
@@ -23,7 +23,7 @@
 
 #include "drawitem.h"
 
-#include "model/drawpoly.h"
+#include <model/drawpoly.h>
 
 class KICAD_EXPORT DrawPolyItem : public DrawItem
 {

--- a/src/kicad/viewer/drawrectitem.h
+++ b/src/kicad/viewer/drawrectitem.h
@@ -23,7 +23,7 @@
 
 #include "drawitem.h"
 
-#include "model/drawrect.h"
+#include <model/drawrect.h>
 
 class KICAD_EXPORT DrawRectItem : public DrawItem
 {

--- a/src/kicad/viewer/drawtextitem.h
+++ b/src/kicad/viewer/drawtextitem.h
@@ -24,7 +24,7 @@
 #include "drawitem.h"
 #include "kicadfont.h"
 
-#include "model/drawtext.h"
+#include <model/drawtext.h>
 
 class KICAD_EXPORT DrawTextItem : public DrawItem
 {

--- a/src/kicad/viewer/pinitem.cpp
+++ b/src/kicad/viewer/pinitem.cpp
@@ -24,7 +24,7 @@
 #include <QDebug>
 #include <QPainter>
 
-#include "model/component.h"
+#include <model/component.h>
 
 PinItem::PinItem(Pin *pin)
 {

--- a/src/kicad/viewer/pinitem.h
+++ b/src/kicad/viewer/pinitem.h
@@ -22,7 +22,7 @@
 #include <QGraphicsItem>
 #include <QtCore/qglobal.h>
 
-#include "model/pin.h"
+#include <model/pin.h>
 
 #include "kicadfont.h"
 

--- a/src/pdf_extract/controller/pdfloader.h
+++ b/src/pdf_extract/controller/pdfloader.h
@@ -21,7 +21,7 @@
 
 #include <pdf_extract_common.h>
 
-#include "model/pdfdatasheet.h"
+#include <model/pdfdatasheet.h>
 
 namespace Poppler
 {

--- a/src/pdf_extract/model/pdfdatasheet.cpp
+++ b/src/pdf_extract/model/pdfdatasheet.cpp
@@ -20,7 +20,7 @@
 
 #include <utility>
 
-#include "controller/pdfloader.h"
+#include <controller/pdfloader.h>
 
 PDFDatasheet::PDFDatasheet(QString fileName)
     : _fileName(std::move(fileName))

--- a/src/pdf_extract/model/pdfpage.cpp
+++ b/src/pdf_extract/model/pdfpage.cpp
@@ -17,7 +17,7 @@
  **/
 
 #include "pdfpage.h"
-#include "controller/pdfloader.h"
+#include <controller/pdfloader.h>
 #include "pdfdatasheet.h"
 
 #include <poppler/qt5/poppler-qt5.h>

--- a/src/pdf_extract/pdfdebugwidget/pdfdebugitempage.h
+++ b/src/pdf_extract/pdfdebugwidget/pdfdebugitempage.h
@@ -23,7 +23,7 @@
 
 #include <QGraphicsItem>
 
-#include "model/pdfpage.h"
+#include <model/pdfpage.h>
 
 class DATASHEET_EXTRACTOR_EXPORT PdfDebugItemPage : public QGraphicsItem
 {

--- a/src/pdf_extract/pdfdebugwidget/pdfdebugitemtextbox.h
+++ b/src/pdf_extract/pdfdebugwidget/pdfdebugitemtextbox.h
@@ -23,7 +23,7 @@
 
 #include <QGraphicsItem>
 
-#include "model/pdftextbox.h"
+#include <model/pdftextbox.h>
 
 class DATASHEET_EXTRACTOR_EXPORT PdfDebugItemTextBox : public QGraphicsItem
 {

--- a/src/pdf_extract/pdfdebugwidget/pdfdebugviewer.h
+++ b/src/pdf_extract/pdfdebugwidget/pdfdebugviewer.h
@@ -23,7 +23,7 @@
 
 #include <QGraphicsView>
 
-#include "model/pdfpage.h"
+#include <model/pdfpage.h>
 #include "pdfdebugitempage.h"
 
 class DATASHEET_EXTRACTOR_EXPORT PdfDebugViewer : public QGraphicsView

--- a/src/pdf_extract/pdfdebugwidget/pdfdebugwidget.h
+++ b/src/pdf_extract/pdfdebugwidget/pdfdebugwidget.h
@@ -26,7 +26,7 @@
 #include <QLineEdit>
 #include <QWidget>
 
-#include "model/pdfdatasheet.h"
+#include <model/pdfdatasheet.h>
 #include "pdfdebugviewer.h"
 
 class DATASHEET_EXTRACTOR_EXPORT PdfDebugWidget : public QWidget

--- a/src/test/test_libkicad.cpp
+++ b/src/test/test_libkicad.cpp
@@ -16,7 +16,7 @@
  ** along with this program. If not, see <http://www.gnu.org/licenses/>.
  **/
 
-#include "model/lib.h"
+#include <model/lib.h>
 
 #include <QDebug>
 #include <QFile>

--- a/src/uconfig_gui/project/uconfigproject.cpp
+++ b/src/uconfig_gui/project/uconfigproject.cpp
@@ -24,7 +24,7 @@
 #include <QRegularExpression>
 #include <QSettings>
 
-#include "importer/pinlistimporter.h"
+#include <importer/pinlistimporter.h>
 
 const int UConfigProject::MaxOldProject = 8;
 

--- a/src/uconfig_gui/project/uconfigproject.h
+++ b/src/uconfig_gui/project/uconfigproject.h
@@ -21,7 +21,7 @@
 
 #include <QObject>
 
-#include "model/lib.h"
+#include <model/lib.h>
 
 class UConfigProject : public QObject
 {

--- a/src/uconfig_gui/uconfigmainwindow.cpp
+++ b/src/uconfig_gui/uconfigmainwindow.cpp
@@ -39,9 +39,9 @@
 
 #include <QDebug>
 
-#include "pinruler/pinruler.h"
-#include "pinruler/rulesparser.h"
-#include "pinruler/rulesset.h"
+#include <pinruler/pinruler.h>
+#include <pinruler/rulesparser.h>
+#include <pinruler/rulesset.h>
 
 UConfigMainWindow::UConfigMainWindow(UConfigProject *project)
     : _project(project)

--- a/src/uconfig_gui/uconfigmainwindow.h
+++ b/src/uconfig_gui/uconfigmainwindow.h
@@ -31,10 +31,10 @@
 #include "project/uconfigproject.h"
 
 #include "componentinfoseditor.h"
-#include "itemmodel/componentlibtreeview.h"
-#include "itemmodel/pinlisteditor.h"
-#include "ksseditor/ksseditor.h"
-#include "viewer/componentwidget.h"
+#include <itemmodel/componentlibtreeview.h>
+#include <itemmodel/pinlisteditor.h>
+#include <ksseditor/ksseditor.h>
+#include <viewer/componentwidget.h>
 
 class UConfigMainWindow : public QMainWindow
 {


### PR DESCRIPTION
Included files that are relative to the current directory should be included as such: 
`#include "relative_path/file.h"`

Included files that are relative to an included path should be included as such:
`#include <some_path/file.h>`

The fact that they worked is somewhat of a bug but it's bad form for humans in all cases.