### PR TITLE
Serious memory bug fix.

### DIFF
--- a/src/kicad/itemmodel/componentlibtreeview.cpp
+++ b/src/kicad/itemmodel/componentlibtreeview.cpp
@@ -55,13 +55,12 @@ Lib *ComponentLibTreeView::lib() const
 
 void ComponentLibTreeView::setLib(Lib *lib)
 {
-    _model->setLib(lib);
-    if (lib == _model->lib())
+    if (lib != _model->lib())
     {
-        return;
+        _model->setLib(lib);
+        resizeColumnToContents(0);
+        resizeColumnToContents(1);
     }
-    resizeColumnToContents(0);
-    resizeColumnToContents(1);
 }
 
 void ComponentLibTreeView::setActiveComponent(Component *component)


### PR DESCRIPTION
The program has been using objects in freed memory since commit 22417ea on Jan 26, 2018.

I was able to find this only because of PR #54 which actually assigned pointers to `nullptr`.  As a result, the program crashed and I quickly found this flaw.