### PR TITLE
Added basic support for importing pin electrical type from a CSV

### DIFF
--- a/src/kicad/schematicsimport/textimporter.cpp
+++ b/src/kicad/schematicsimport/textimporter.cpp
@@ -22,12 +22,27 @@
 #include <QFile>
 #include <QFileInfo>
 
+static const QMap<QString, Pin::ElectricalType> pinElectricalTypeMap = {
+    {"Input", Pin::ElectricalType::Input},
+    {"Output", Pin::ElectricalType::Output},
+    {"Bidir", Pin::ElectricalType::Bidir},
+    {"Tristate", Pin::ElectricalType::Tristate},
+    {"Passive", Pin::ElectricalType::Passive},
+    {"Unspecified", Pin::ElectricalType::Unspecified},
+    {"PowerIn", Pin::ElectricalType::PowerIn},
+    {"PowerOut", Pin::ElectricalType::PowerOut},
+    {"OpenCollector", Pin::ElectricalType::OpenCollector},
+    {"OpenEmitter", Pin::ElectricalType::OpenEmitter},
+    {"NotConnected", Pin::ElectricalType::NotConnected}
+};
+
 TextImporter::TextImporter()
 {
     _columnSeparator = '\t';
     _pinColumn = 0;
     _pinNameColumns = {1};
     _pinNameColumnsSeparator = '/';
+    _pinElectricalTypeColumn = 2;
 }
 
 QChar TextImporter::columnSeparator() const
@@ -68,6 +83,16 @@ int TextImporter::pinColumn() const
 void TextImporter::setPinColumn(int pinColumn)
 {
     _pinColumn = pinColumn;
+}
+
+int TextImporter::pinElectricalTypeColumn() const
+{
+    return _pinElectricalTypeColumn;
+}
+
+void TextImporter::setPinElectricalTypeColumn(int pinElectricalTypeColumn)
+{
+    _pinElectricalTypeColumn = pinElectricalTypeColumn;
 }
 
 bool TextImporter::import(const QString &fileName)
@@ -115,8 +140,19 @@ bool TextImporter::import(const QString &fileName)
             pinNameColumns.append(columns[column]);
         }
         QString pinName = pinNameColumns.join(_pinNameColumnsSeparator);
+        QString pinElectricalType = columns[_pinElectricalTypeColumn];
+
+        Pin::ElectricalType electricalType = Pin::ElectricalType::Unspecified;
+
+        if (pinElectricalTypeMap.contains(pinElectricalType))
+        {
+            electricalType = pinElectricalTypeMap.value(pinElectricalType);
+        }
 
         Pin *pin = new Pin(pinName, pinNumber);
+
+        pin->setElectricalType(electricalType);
+
         component->addPin(pin);
     }
 

--- a/src/kicad/schematicsimport/textimporter.h
+++ b/src/kicad/schematicsimport/textimporter.h
@@ -40,11 +40,15 @@ public:
     QChar pinNameColumnsSeparator() const;
     void setPinNameColumnsSeparator(const QChar &pinNameColumnsSeparator);
 
+    int pinElectricalTypeColumn() const;
+    void setPinElectricalTypeColumn(int pinColumn);
+
 protected:
     QChar _columnSeparator;
     int _pinColumn;
     QList<int> _pinNameColumns;
     QChar _pinNameColumnsSeparator;
+    int _pinElectricalTypeColumn;
 
     // SchematicsImporter interface
 public:


### PR DESCRIPTION
I've added a basic set of functions to enable importing of pin electrical type descriptions from a CSV file. Tested and working with a 960-pin BGA CSV file.

By default they're the third column, and the default option is "unspecified". I'm happy to expand on this and add support for pinType, but I thought I'd check since electricalType is necessary when trying to get ERC to pass, and probably the most common extra column included on a datasheet!